### PR TITLE
新增正式部署後自動驗收

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,39 @@
+name: Production Smoke
+
+on:
+  deployment_status:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.deployment_status.state == 'success' &&
+        github.event.deployment.environment == 'Production'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: astro-site
+    steps:
+      - name: Check out the production checks
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Verify the production deployment
+        run: npm run smoke:production

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ npm run dev
 `misstravel.me`，讓 `vercel.json` 能將裸網域永久轉址到 `www`；
 DNS 也應讓兩個網域都指向同一個 Vercel 專案。
 
+Vercel 回報 Production 部署成功後，GitHub Actions 會自動執行正式環境
+smoke test，驗證裸網域轉址、核心頁面、canonical、結構化資料、
+robots.txt、sitemap 與 RoomCloud 訂房連結。也可以在 Actions 頁面手動
+執行 `Production Smoke`，或於 `astro-site` 目錄執行：
+
+```bash
+npm run smoke:production
+```
+
 ## 網站
 
 - 正式環境：https://www.misstravel.me

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -8,7 +8,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run",
-    "verify": "npm audit --audit-level=high && vitest run"
+    "verify": "npm audit --audit-level=high && vitest run",
+    "smoke:production": "node scripts/production-smoke.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",

--- a/astro-site/scripts/production-smoke.mjs
+++ b/astro-site/scripts/production-smoke.mjs
@@ -1,0 +1,271 @@
+import { pathToFileURL } from 'node:url';
+
+export const WWW_ORIGIN = 'https://www.misstravel.me';
+export const APEX_ORIGIN = 'https://misstravel.me';
+export const EXPECTED_SITEMAP_PATHS = [
+  '/',
+  '/announcements/',
+  '/announcements/website/',
+  '/galleries/',
+  '/infos/',
+  '/infos/account/',
+  '/infos/contact-method/',
+  '/infos/guide/',
+  '/infos/map/',
+  '/infos/menu/',
+  '/infos/roles/',
+  '/infos/set-menu-info/',
+  '/infos/video/',
+  '/rooms/',
+  '/rooms/campsite_1/',
+  '/rooms/campsite_2/',
+  '/rooms/campsite_3/',
+  '/rooms/log_cabin_1/',
+  '/rooms/log_cabin_2/',
+  '/rooms/log_cabin_3/',
+  '/rooms/log_cabin_4/',
+  '/rooms/suite_1/',
+  '/rooms/suite_2/',
+  '/rooms/suite_3/',
+  '/sale_items/',
+];
+
+const RETRY_ATTEMPTS = 6;
+const RETRY_DELAY_MS = 10_000;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function openingTags(html, name) {
+  return html.match(new RegExp(`<${name}\\b[^>]*>`, 'gi')) ?? [];
+}
+
+function attribute(tag, name) {
+  const attributes = new Map();
+  const pattern = /([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+
+  for (const match of tag.matchAll(pattern)) {
+    attributes.set(match[1].toLowerCase(), match[2] ?? match[3] ?? '');
+  }
+
+  return attributes.get(name.toLowerCase());
+}
+
+export function canonicalUrl(html) {
+  const links = openingTags(html, 'link').filter((tag) =>
+    attribute(tag, 'rel')?.toLowerCase().split(/\s+/).includes('canonical'),
+  );
+
+  invariant(links.length === 1, `expected one canonical link, found ${links.length}`);
+  return attribute(links[0], 'href');
+}
+
+export function metaContent(html, selector, value) {
+  const matches = openingTags(html, 'meta').filter(
+    (tag) => attribute(tag, selector)?.toLowerCase() === value.toLowerCase(),
+  );
+
+  invariant(matches.length === 1, `expected one meta[${selector}="${value}"], found ${matches.length}`);
+  return attribute(matches[0], 'content');
+}
+
+export function jsonLdDocuments(html) {
+  const scripts = html.matchAll(
+    /<script\b([^>]*)>([\s\S]*?)<\/script>/gi,
+  );
+  const documents = [];
+
+  for (const match of scripts) {
+    const type = attribute(`<script ${match[1]}>`, 'type');
+    if (type?.toLowerCase() === 'application/ld+json') {
+      documents.push(JSON.parse(match[2]));
+    }
+  }
+
+  return documents;
+}
+
+export function absoluteLinks(html) {
+  return openingTags(html, 'a')
+    .map((tag) => attribute(tag, 'href'))
+    .filter((href) => href?.startsWith('https://'));
+}
+
+export function assertRedirect(status, location, expectedUrl) {
+  invariant(status === 308, `expected HTTP 308, received ${status}`);
+  invariant(location, 'redirect response did not include a Location header');
+
+  const actual = new URL(location, APEX_ORIGIN).href;
+  invariant(actual === expectedUrl, `expected redirect to ${expectedUrl}, received ${actual}`);
+}
+
+export function assertHtmlPage(html, expectedCanonical, { requireBookingLink = false } = {}) {
+  invariant(canonicalUrl(html) === expectedCanonical, `canonical did not equal ${expectedCanonical}`);
+  invariant(
+    metaContent(html, 'property', 'og:url') === expectedCanonical,
+    `og:url did not equal ${expectedCanonical}`,
+  );
+  invariant(
+    metaContent(html, 'name', 'twitter:url') === expectedCanonical,
+    `twitter:url did not equal ${expectedCanonical}`,
+  );
+
+  const schemas = jsonLdDocuments(html);
+  invariant(schemas.length > 0, 'page did not include valid JSON-LD');
+
+  const serializedSchemas = JSON.stringify(schemas);
+  invariant(
+    !serializedSchemas.includes('https://misstravel.me'),
+    'JSON-LD contained the bare domain',
+  );
+
+  if (requireBookingLink) {
+    const bookingLinks = absoluteLinks(html).filter((href) => {
+      const hostname = new URL(href).hostname;
+      return hostname === 'roomcloud.cc' || hostname.endsWith('.roomcloud.cc');
+    });
+
+    invariant(bookingLinks.length > 0, 'page did not include an HTTPS RoomCloud booking link');
+  }
+}
+
+export function assertRobots(body) {
+  invariant(
+    body.includes(`Sitemap: ${WWW_ORIGIN}/sitemap-index.xml`),
+    'robots.txt did not advertise the canonical sitemap',
+  );
+  invariant(!body.includes(`${APEX_ORIGIN}/`), 'robots.txt contained the bare domain');
+}
+
+export function sitemapLocations(body) {
+  return [...body.matchAll(/<loc>([^<]+)<\/loc>/gi)].map((match) => match[1].trim());
+}
+
+export function assertSitemapIndex(body) {
+  const locations = sitemapLocations(body);
+  invariant(locations.length > 0, 'sitemap index did not contain any sitemap locations');
+  invariant(
+    locations.includes(`${WWW_ORIGIN}/sitemap-0.xml`),
+    'sitemap index did not include sitemap-0.xml',
+  );
+  invariant(
+    locations.every((location) => location.startsWith(`${WWW_ORIGIN}/`)),
+    'sitemap index contained a non-canonical origin',
+  );
+}
+
+export function assertSitemap(body) {
+  const locations = sitemapLocations(body);
+  invariant(
+    locations.every((location) => location.startsWith(`${WWW_ORIGIN}/`)),
+    'sitemap contained a non-canonical origin',
+  );
+
+  const missing = EXPECTED_SITEMAP_PATHS.filter(
+    (pathname) => !locations.includes(`${WWW_ORIGIN}${pathname}`),
+  );
+  invariant(missing.length === 0, `sitemap was missing expected paths: ${missing.join(', ')}`);
+}
+
+const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function eventually(label, callback) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      await callback();
+      console.log(`✓ ${label}`);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < RETRY_ATTEMPTS) {
+        console.warn(`Retrying ${label} (${attempt}/${RETRY_ATTEMPTS}): ${error.message}`);
+        await wait(RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  throw new Error(`${label}: ${lastError?.message ?? 'unknown failure'}`);
+}
+
+async function request(url, { redirect = 'follow' } = {}) {
+  const response = await fetch(url, {
+    redirect,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: {
+      accept: '*/*',
+      'cache-control': 'no-cache',
+      'user-agent': 'misstravel-production-smoke/1.0',
+    },
+  });
+
+  const body = await response.text();
+  return { response, body };
+}
+
+async function expectOk(url, expectedContentType) {
+  const { response, body } = await request(url);
+  invariant(response.status === 200, `${url} returned HTTP ${response.status}`);
+  invariant(
+    response.headers.get('content-type')?.includes(expectedContentType),
+    `${url} returned an unexpected Content-Type`,
+  );
+  return body;
+}
+
+export async function runProductionSmoke() {
+  const marker = encodeURIComponent(process.env.GITHUB_SHA ?? Date.now().toString());
+  const deepPath = `/rooms/campsite_1/?production_smoke=${marker}`;
+  const expectedRedirect = `${WWW_ORIGIN}${deepPath}`;
+  const freshUrl = (pathname) => {
+    const url = new URL(pathname, WWW_ORIGIN);
+    url.searchParams.set('production_smoke', marker);
+    return url.href;
+  };
+
+  await eventually('bare domain preserves a deep path and query with HTTP 308', async () => {
+    const { response } = await request(`${APEX_ORIGIN}${deepPath}`, { redirect: 'manual' });
+    assertRedirect(response.status, response.headers.get('location'), expectedRedirect);
+  });
+
+  const pages = [
+    ['homepage', '/', true],
+    ['rooms page', '/rooms/', false],
+    ['representative room page', '/rooms/campsite_1/', true],
+  ];
+
+  for (const [label, pathname, requireBookingLink] of pages) {
+    await eventually(`${label} metadata and schema`, async () => {
+      const body = await expectOk(freshUrl(pathname), 'text/html');
+      assertHtmlPage(body, `${WWW_ORIGIN}${pathname}`, { requireBookingLink });
+    });
+  }
+
+  await eventually('robots.txt', async () => {
+    const body = await expectOk(freshUrl('/robots.txt'), 'text/plain');
+    assertRobots(body);
+  });
+
+  await eventually('sitemap index', async () => {
+    const body = await expectOk(freshUrl('/sitemap-index.xml'), 'xml');
+    assertSitemapIndex(body);
+  });
+
+  await eventually('sitemap URLs', async () => {
+    const body = await expectOk(freshUrl('/sitemap-0.xml'), 'xml');
+    assertSitemap(body);
+  });
+}
+
+const isDirectRun = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  runProductionSmoke().catch((error) => {
+    console.error(`✗ ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/astro-site/tests/production-smoke.test.ts
+++ b/astro-site/tests/production-smoke.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertHtmlPage,
+  assertRedirect,
+  assertRobots,
+  assertSitemap,
+  assertSitemapIndex,
+  EXPECTED_SITEMAP_PATHS,
+  jsonLdDocuments,
+} from '../scripts/production-smoke.mjs';
+
+const canonical = 'https://www.misstravel.me/rooms/campsite_1/';
+
+const validHtml = `
+  <!doctype html>
+  <html>
+    <head>
+      <link href="${canonical}" rel="canonical">
+      <meta content="${canonical}" property="og:url">
+      <meta name="twitter:url" content="${canonical}">
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","url":"${canonical}"}
+      </script>
+    </head>
+    <body>
+      <a href="https://roomcloud.cc/booking/example">訂房</a>
+    </body>
+  </html>
+`;
+
+describe('正式環境 smoke 檢查器', () => {
+  it('接受順序不同但完整的 canonical metadata 與 RoomCloud 連結', () => {
+    expect(() => assertHtmlPage(validHtml, canonical, { requireBookingLink: true })).not.toThrow();
+    expect(jsonLdDocuments(validHtml)).toHaveLength(1);
+  });
+
+  it('拒絕重複 canonical、裸網域 schema 與非 HTTPS 訂房連結', () => {
+    expect(() => assertHtmlPage(
+      validHtml.replace('</head>', `<link rel="canonical" href="${canonical}"></head>`),
+      canonical,
+    )).toThrow(/one canonical/);
+
+    expect(() => assertHtmlPage(
+      validHtml.replace(canonical, 'https://misstravel.me/rooms/campsite_1/'),
+      canonical,
+    )).toThrow();
+
+    expect(() => assertHtmlPage(
+      validHtml.replace('https://roomcloud.cc', 'http://roomcloud.cc'),
+      canonical,
+      { requireBookingLink: true },
+    )).toThrow(/RoomCloud/);
+  });
+
+  it('只接受保留完整 path 與 query 的 308 轉址', () => {
+    const expected = `${canonical}?production_smoke=abc`;
+
+    expect(() => assertRedirect(308, expected, expected)).not.toThrow();
+    expect(() => assertRedirect(307, expected, expected)).toThrow(/308/);
+    expect(() => assertRedirect(308, canonical, expected)).toThrow(/expected redirect/);
+  });
+
+  it('驗證 robots 與 sitemap 僅使用 canonical 網域', () => {
+    expect(() => assertRobots(
+      'User-agent: *\nAllow: /\nSitemap: https://www.misstravel.me/sitemap-index.xml\n',
+    )).not.toThrow();
+
+    expect(() => assertSitemapIndex(
+      '<sitemapindex><sitemap><loc>https://www.misstravel.me/sitemap-0.xml</loc></sitemap></sitemapindex>',
+    )).not.toThrow();
+
+    const urls = EXPECTED_SITEMAP_PATHS.map(
+      (pathname) => `https://www.misstravel.me${pathname}`,
+    );
+    const sitemap = `<urlset>${urls.map((url) => `<url><loc>${url}</loc></url>`).join('')}</urlset>`;
+
+    expect(() => assertSitemap(sitemap)).not.toThrow();
+    expect(() => assertSitemap(sitemap.replace(
+      'https://www.misstravel.me/infos/',
+      'https://misstravel.me/infos/',
+    ))).toThrow(/non-canonical/);
+    expect(() => assertSitemap(sitemap.replace(
+      '<url><loc>https://www.misstravel.me/rooms/</loc></url>',
+      '',
+    ))).toThrow(/missing expected paths/);
+  });
+});


### PR DESCRIPTION
## 變更內容

- 新增 `Production Smoke` GitHub Actions workflow
  - Vercel 回報 `Production` deployment 成功後自動執行
  - 支援從 Actions 頁面手動重跑
  - 權限維持 `contents: read`
  - Actions 仍以完整 commit SHA 鎖定
- 新增無外部套件的 production smoke runner
  - 驗證裸網域以 308 保留深層 path 與 query
  - 驗證首頁、房型列表與代表房型頁為 200
  - 驗證 canonical、OG URL、Twitter URL 與 JSON-LD
  - 驗證 HTTPS RoomCloud 訂房連結
  - 驗證 robots、sitemap index 與 25 條正式 sitemap 路徑
  - 使用部署 SHA 作 cache-busting，避免 CDN 舊 HTML 造成假性回歸
  - 對部署傳播延遲提供有限次重試與 request timeout
- 新增 smoke parser／斷言的離線回歸測試與 README 說明

## 驗收

- `npm run verify`
- 26 個靜態頁面建置成功
- 9 個測試檔、120 項測試全數通過
- `npm audit`: 0 vulnerabilities
- workflow YAML 可解析
- 遠端 tree `989fe2b…` 與本機驗收 tree 完全相同
- 已用現有 Vercel deployment payload 確認事件環境名稱為 `Production`

## 合併前阻擋事項

正式裸網域目前實測回傳 **307**，雖然 path 與 query 有保留，但不是 `vercel.json` 的永久 **308**。Response 同時帶有 `x-vercel-id`，而程式庫設定已是 `permanent: true`，顯示 Vercel 控制台的網域層 redirect 很可能先於專案 routing 執行。

請先在 Vercel Project Settings → Domains 檢查 `misstravel.me`：它應連接 Production environment，而不是使用「Redirect to Another Domain」。讓請求進入專案後，`vercel.json` 才能產生 308。修正後應以深層網址加 query 實測狀態碼、Location 與無迴圈，再把本 PR 轉為 Ready。

目前保留 Draft，因為若直接合併，新的 smoke workflow 會正確地因 307 而失敗。

## 對抗審查發現

- 正式 sitemap 是 25 條可索引 URL；第 26 個 HTML 是 404，不應出現在 sitemap。檢查器已改成驗證完整 25 條路徑。
- 同一時間不同節點可能讀到新舊兩版 metadata；舊回應帶 `max-age=3600` 與 cache hit。runner 因此以 deployment SHA 查詢最新部署內容，不把 CDN 舊快取誤判成程式回歸。