### PR TITLE
依房型分類住宿政策與推薦

### DIFF
--- a/astro-site/src/components/RoomPolicyNotice.astro
+++ b/astro-site/src/components/RoomPolicyNotice.astro
@@ -1,0 +1,18 @@
+---
+import type { RoomType } from '../lib/room-policy';
+import { ROOM_TYPE_LABELS, ROOM_TYPE_POLICIES, SHARED_POLICIES } from '../lib/room-policy';
+
+interface Props {
+  roomType: RoomType;
+}
+
+const { roomType } = Astro.props;
+---
+
+<section class="booking-notice" data-room-type={roomType} aria-labelledby="booking-policy-title">
+  <h3 id="booking-policy-title">【{ROOM_TYPE_LABELS[roomType]}訂位須知】</h3>
+  <ul>
+    {ROOM_TYPE_POLICIES[roomType].map((policy) => <li>{policy}</li>)}
+    {SHARED_POLICIES.map((policy) => <li>{policy}</li>)}
+  </ul>
+</section>

--- a/astro-site/src/lib/room-policy.ts
+++ b/astro-site/src/lib/room-policy.ts
@@ -1,0 +1,77 @@
+export type RoomType = 'campsite' | 'cabin' | 'suite';
+
+export interface RoomSummary {
+  id: string;
+  data: {
+    numberOfPeople: number;
+    weekdayPrice: number;
+    order: number;
+  };
+}
+
+export const SHARED_POLICIES = [
+  '訪客須事先登記，每人酌收 100 元清潔費；晚上 5 點後不再開放訪客入場，已入場訪客須於晚上 8 點前離開。',
+  '為響應環保，園內住宿不提供毛巾、浴巾、牙刷等盥洗用品，請自行準備。',
+] as const;
+
+export const ROOM_TYPE_POLICIES: Record<RoomType, readonly string[]> = {
+  campsite: [
+    '營位及露營木屋不提供早晚餐。',
+    '一帳以一車四人為原則；加人、加車及加帳費用另計。',
+    '攜帶寵物離開預訂區域時請繫繩，未繫繩將酌收每隻 100 元清潔費。',
+    '烤肉架、焚火台或快速爐須架高並離地 60 公分以上，不得直接在草皮或木板上使用。',
+  ],
+  cabin: [
+    '露營木屋不提供早晚餐。',
+    '木屋區嚴禁攜帶寵物；需要攜帶寵物請改訂露營營位。',
+    '木屋內禁止吸菸及炊煮食物。',
+  ],
+  suite: [
+    '套房於假日及連續假期附早餐，平日不附早餐；園區不提供晚餐。',
+    '套房內禁止吸菸及炊煮食物。',
+  ],
+};
+
+export const ROOM_TYPE_LABELS: Record<RoomType, string> = {
+  campsite: '露營營位',
+  cabin: '露營木屋',
+  suite: '園區套房',
+};
+
+export const ROOM_TYPE_TIMES: Record<RoomType, { checkinTime: string; checkoutTime: string }> = {
+  campsite: { checkinTime: '13:00', checkoutTime: '12:00' },
+  cabin: { checkinTime: '15:00', checkoutTime: '12:00' },
+  suite: { checkinTime: '15:00', checkoutTime: '12:00' },
+};
+
+export function roomTypeFromId(id: string): RoomType {
+  if (id.startsWith('campsite_')) return 'campsite';
+  if (id.startsWith('log_cabin_')) return 'cabin';
+  if (id.startsWith('suite_')) return 'suite';
+  throw new Error(`Unknown room type for ${id}`);
+}
+
+export function policiesForRoom(id: string) {
+  const roomType = roomTypeFromId(id);
+  return {
+    roomType,
+    label: ROOM_TYPE_LABELS[roomType],
+    times: ROOM_TYPE_TIMES[roomType],
+    shared: SHARED_POLICIES,
+    specific: ROOM_TYPE_POLICIES[roomType],
+  };
+}
+
+export function relatedRoomScore(current: RoomSummary, candidate: RoomSummary) {
+  const sameType = roomTypeFromId(current.id) === roomTypeFromId(candidate.id);
+  const peopleDifference = Math.abs(current.data.numberOfPeople - candidate.data.numberOfPeople);
+  const priceDifference = Math.abs(current.data.weekdayPrice - candidate.data.weekdayPrice);
+  return (sameType ? 0 : 1_000_000) + peopleDifference * 10_000 + priceDifference + candidate.data.order;
+}
+
+export function selectRelatedRooms<T extends RoomSummary>(current: T, rooms: T[], limit = 3) {
+  return rooms
+    .filter((room) => room.id !== current.id)
+    .sort((a, b) => relatedRoomScore(current, a) - relatedRoomScore(current, b))
+    .slice(0, limit);
+}

--- a/astro-site/src/pages/rooms/[...slug].astro
+++ b/astro-site/src/pages/rooms/[...slug].astro
@@ -1,8 +1,10 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Breadcrumb from '../../components/Breadcrumb.astro';
+import RoomPolicyNotice from '../../components/RoomPolicyNotice.astro';
 import { getCollection, render } from 'astro:content';
 import { siteConfig } from '../../lib/config';
+import { policiesForRoom, selectRelatedRooms } from '../../lib/room-policy';
 
 export async function getStaticPaths() {
   const rooms = await getCollection('rooms');
@@ -14,19 +16,30 @@ export async function getStaticPaths() {
 
 const { room } = Astro.props;
 const { Content } = await render(room);
+const roomId = room.id.replace('.md', '');
+const policy = policiesForRoom(roomId);
 
 const carouselImages = room.data.images.includes(room.data.mainImage)
   ? room.data.images
   : [room.data.mainImage, ...room.data.images];
 
-// Get related rooms (same type or different)
 const allRooms = await getCollection('rooms');
-const relatedRooms = allRooms
-  .filter((r) => r.id !== room.id)
-  .sort((a, b) => a.data.order - b.data.order)
-  .slice(0, 3);
+const relatedRooms = selectRelatedRooms(room, allRooms);
 
-const roomUrl = `${siteConfig.url}/rooms/${room.id.replace('.md', '')}/`;
+const roomUrl = `${siteConfig.url}/rooms/${roomId}/`;
+const accommodationSchemaData = {
+  name: room.data.title,
+  description: room.data.metaDescription || room.data.description,
+  image: carouselImages.map((img) => `${siteConfig.url}${img}`),
+  url: roomUrl,
+  checkinTime: policy.times.checkinTime,
+  checkoutTime: policy.times.checkoutTime,
+  accommodationCategory: policy.label,
+  occupancy: {
+    '@type': 'QuantitativeValue',
+    maxValue: room.data.numberOfPeople,
+  },
+};
 const productSchema = {
   '@context': 'https://schema.org',
   '@type': 'Product',
@@ -54,7 +67,8 @@ const productSchema = {
   keywords={room.data.keywords}
   image={room.data.mainImage}
   preloadImage={carouselImages[0]}
-  schemaType="LocalBusiness"
+  schemaType="Accommodation"
+  schemaData={accommodationSchemaData}
   extraSchemas={[productSchema]}
 >
   <main id="main" class="alt">
@@ -63,117 +77,99 @@ const productSchema = {
         { label: '房型展示', href: '/rooms/' },
         { label: room.data.shortTitle }
       ]} />
-    <header class="major">
-      <h1>{room.data.title}</h1>
-    </header>
-  </div>
+      <header class="major">
+        <h1>{room.data.title}</h1>
+      </header>
+    </div>
 
-  <div id="main-content" class="room-detail">
-    <div class="inner-content">
-      <!-- Important Notice -->
-      <h2 class="notice-title">『預訂前請先詳閱以下介紹(含延期退費說明)並衡量房間大小是否合適』</h2>
+    <div id="main-content" class="room-detail">
+      <div class="inner-content">
+        <h2 class="notice-title">『預訂前請先詳閱以下介紹（含延期退費說明）並衡量空間是否合適』</h2>
 
-      <!-- Image Carousel -->
-      <div class="carousel-container">
-        <div class="carousel" id="room-carousel">
-          <div class="carousel-track">
-            {carouselImages.map((image, index) => (
-              <div class="carousel-slide" data-index={index}>
-                <img
-                  src={image}
-                  alt={`${room.data.shortTitle} 圖片 ${index + 1}`}
-                  loading={index === 0 ? 'eager' : 'lazy'}
-                  decoding="async"
-                  fetchpriority={index === 0 ? 'high' : undefined}
-                  width="900"
-                  height="675"
-                />
-              </div>
-            ))}
-          </div>
-          <button class="carousel-btn prev" aria-label="上一張">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="15 18 9 12 15 6"></polyline>
-            </svg>
-          </button>
-          <button class="carousel-btn next" aria-label="下一張">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="9 18 15 12 9 6"></polyline>
-            </svg>
-          </button>
-          <div class="carousel-dots">
-            {carouselImages.map((_, index) => (
-              <button
-                class={`dot ${index === 0 ? 'active' : ''}`}
-                data-index={index}
-                aria-label={`跳至圖片 ${index + 1}`}
-              ></button>
-            ))}
+        <div class="carousel-container">
+          <div class="carousel" id="room-carousel">
+            <div class="carousel-track">
+              {carouselImages.map((image, index) => (
+                <div class="carousel-slide" data-index={index}>
+                  <img
+                    src={image}
+                    alt={`${room.data.shortTitle} 圖片 ${index + 1}`}
+                    loading={index === 0 ? 'eager' : 'lazy'}
+                    decoding="async"
+                    fetchpriority={index === 0 ? 'high' : undefined}
+                    width="900"
+                    height="675"
+                  />
+                </div>
+              ))}
+            </div>
+            <button class="carousel-btn prev" aria-label="上一張">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <polyline points="15 18 9 12 15 6"></polyline>
+              </svg>
+            </button>
+            <button class="carousel-btn next" aria-label="下一張">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <polyline points="9 18 15 12 9 6"></polyline>
+              </svg>
+            </button>
+            <div class="carousel-dots">
+              {carouselImages.map((_, index) => (
+                <button
+                  class={`dot ${index === 0 ? 'active' : ''}`}
+                  data-index={index}
+                  aria-label={`跳至圖片 ${index + 1}`}
+                ></button>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
 
-      <!-- Action Buttons -->
-      <div class="action-buttons">
-        <a href={siteConfig.urls.account} class="btn-action">訂房流程</a>
-        <a href={siteConfig.urls.roles} class="btn-action special">園內規約</a>
-      </div>
+        <div class="action-buttons">
+          <a href={siteConfig.booking.url} class="btn-action" target="_blank" rel="noopener noreferrer">查詢空房</a>
+          <a href={siteConfig.contact.lineUrl} class="btn-action line" target="_blank" rel="noopener noreferrer">LINE 詢問</a>
+          <a href={siteConfig.urls.account} class="btn-action">訂房流程</a>
+          <a href={siteConfig.urls.roles} class="btn-action special">園內規約</a>
+        </div>
 
-      <!-- Booking Notice -->
-      <div class="booking-notice">
-        <h3>【訂位須知】</h3>
-        <ul>
-          <li>訂假日提早一晚夜衝者，當日價格一律半價(限晚上 6 點後至 10 點以前進場)</li>
-          <li>營區及露營木屋無提供早晚餐，套房假日、連續假期附早餐（平日不附），無提供晚餐</li>
-          <li>嚴禁直接在草皮或木板上烤肉及烹煮。若使用烤肉架、焚火台或快速爐等用具，請務必自備架高器具，並離地 60 公分以上</li>
-          <li class="red">木屋區嚴禁攜帶寵物，如欲攜帶寵物請預訂露營營位</li>
-          <li class="red">營位攜帶寵物如離開預訂區域請繫繩，如未繫繩將酌收 100 清潔費用/隻</li>
-          <li>如攜帶訪客入場每人酌收 100 元清潔費，不可抵園區消費，需於晚上 8 點前離開園區，如超過則再加收每人 100 元共計 200 元的加人費。如未登記也未主動告知有訪客，事後被營主發現得勒令立即離場</li>
-          <li>晚上 5 點後訪客禁止進入</li>
-          <li>一帳限一車四人 (加人、加車費另計，加帳一律 800 元)</li>
-          <li>為響應環保，園內住宿無提供盥洗用品，請自備毛巾及浴巾牙刷等盥洗用具</li>
-        </ul>
-      </div>
+        <RoomPolicyNotice roomType={policy.roomType} />
 
-      <!-- Room Details -->
-      <div class="room-content">
-        <Content />
-      </div>
+        <div class="room-content">
+          <Content />
+        </div>
 
-      <!-- Day Type Definition -->
-      <div class="day-definition">
-        <h3>【平日、假日定義】</h3>
-        <ul>
-          <li>平日：星期日至星期四</li>
-          <li>假日：星期五、星期六、國定假日</li>
-          <li>連續假日包含年節期間及國定假日(含連休假期前一晚)</li>
-        </ul>
-      </div>
+        <div class="day-definition">
+          <h3>【平日、假日定義】</h3>
+          <ul>
+            <li>平日：星期日至星期四</li>
+            <li>假日：星期五、星期六、國定假日</li>
+            <li>連續假日包含年節期間及國定假日（含連休假期前一晚）</li>
+          </ul>
+        </div>
 
-      <!-- Related Rooms -->
-      <div class="related-section">
-        <h3>其他住宿選擇</h3>
-        <div class="related-grid">
-          {relatedRooms.map((related) => (
-            <a href={`/rooms/${related.id.replace('.md', '')}/`} class="related-card">
-              <img
-                src={related.data.mainImage}
-                alt={`${related.data.shortTitle}住宿外觀`}
-                loading="lazy"
-                decoding="async"
-                width="400"
-                height="150"
-              />
-              <div class="related-info">
-                <h4>{related.data.shortTitle}</h4>
-                <span class="related-price">平日 ${related.data.weekdayPrice} 起</span>
-              </div>
-            </a>
-          ))}
+        <div class="related-section">
+          <h3>相近住宿選擇</h3>
+          <div class="related-grid">
+            {relatedRooms.map((related) => (
+              <a href={`/rooms/${related.id.replace('.md', '')}/`} class="related-card">
+                <img
+                  src={related.data.mainImage}
+                  alt={`${related.data.shortTitle}住宿外觀`}
+                  loading="lazy"
+                  decoding="async"
+                  width="400"
+                  height="150"
+                />
+                <div class="related-info">
+                  <h4>{related.data.shortTitle}</h4>
+                  <span class="related-price">平日 ${related.data.weekdayPrice} 起</span>
+                </div>
+              </a>
+            ))}
+          </div>
         </div>
       </div>
     </div>
-  </div>
   </main>
 </BaseLayout>
 
@@ -184,10 +180,16 @@ const productSchema = {
     padding-bottom: 0;
   }
 
-  #main.alt > .inner {
+  #main.alt > .inner,
+  .inner-content {
     max-width: 900px;
     margin: 0 auto;
-    padding: 0 1.5rem 1rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  #main.alt > .inner {
+    padding-bottom: 1rem;
   }
 
   .major h1 {
@@ -204,13 +206,6 @@ const productSchema = {
     padding: 2rem 0 4rem;
   }
 
-  .inner-content {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
-  }
-
-  /* Notice Title */
   .notice-title {
     color: #ffd306;
     font-size: 1.35em;
@@ -219,7 +214,6 @@ const productSchema = {
     line-height: 1.6;
   }
 
-  /* Carousel */
   .carousel-container {
     margin-bottom: 2rem;
   }
@@ -264,17 +258,13 @@ const productSchema = {
     transition: background 0.2s ease;
   }
 
-  .carousel-btn:hover {
-    background: rgba(0, 0, 0, 0.7);
+  .carousel-btn:hover,
+  .carousel-btn:focus-visible {
+    background: rgba(0, 0, 0, 0.8);
   }
 
-  .carousel-btn.prev {
-    left: 1rem;
-  }
-
-  .carousel-btn.next {
-    right: 1rem;
-  }
+  .carousel-btn.prev { left: 1rem; }
+  .carousel-btn.next { right: 1rem; }
 
   .carousel-dots {
     position: absolute;
@@ -286,43 +276,48 @@ const productSchema = {
   }
 
   .dot {
-    width: 10px;
-    height: 10px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
     border: none;
     background: rgba(255, 255, 255, 0.5);
     cursor: pointer;
-    transition: background 0.2s ease;
   }
 
-  .dot.active {
-    background: #fff;
-  }
+  .dot.active { background: #fff; }
 
-  /* Action Buttons */
   .action-buttons {
     display: flex;
     justify-content: center;
-    gap: 1.5rem;
+    flex-wrap: wrap;
+    gap: 0.75rem;
     margin-bottom: 2rem;
   }
 
   .btn-action {
-    display: inline-block;
-    padding: 0.75rem 2rem;
-    font-size: 0.9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    padding: 0.65rem 1.25rem;
+    font-size: 0.85rem;
     font-weight: 600;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
+    letter-spacing: 0.12em;
     border: 2px solid #fff;
     background: transparent;
     color: #fff;
     transition: all 0.2s ease;
   }
 
-  .btn-action:hover {
+  .btn-action:hover,
+  .btn-action:focus-visible {
     background: rgba(255, 255, 255, 0.1);
     color: #fff;
+  }
+
+  .btn-action.line {
+    border-color: #9bf1ff;
+    color: #9bf1ff;
   }
 
   .btn-action.special {
@@ -330,37 +325,30 @@ const productSchema = {
     color: #242943;
   }
 
-  .btn-action.special:hover {
-    background: rgba(255, 255, 255, 0.9);
-  }
-
-  /* Booking Notice */
-  .booking-notice {
+  .booking-notice,
+  .day-definition,
+  .room-content {
     margin-bottom: 2rem;
   }
 
-  .booking-notice h3 {
+  .booking-notice h3,
+  .day-definition h3 {
     color: #fff;
     font-size: 1.1em;
     margin-bottom: 1rem;
   }
 
-  .booking-notice ul {
+  .booking-notice ul,
+  .day-definition ul,
+  .room-content :global(ul) {
     padding-left: 1.5rem;
   }
 
-  .booking-notice li {
+  .booking-notice li,
+  .day-definition li,
+  .room-content :global(li) {
     margin-bottom: 0.5rem;
     color: rgba(255, 255, 255, 0.9);
-  }
-
-  .booking-notice li.red {
-    color: #ff6b6b;
-  }
-
-  /* Room Content */
-  .room-content {
-    margin-bottom: 2rem;
   }
 
   .room-content :global(h4) {
@@ -370,37 +358,6 @@ const productSchema = {
     margin-bottom: 1rem;
   }
 
-  .room-content :global(ul) {
-    padding-left: 1.5rem;
-    margin-bottom: 1rem;
-  }
-
-  .room-content :global(li) {
-    margin-bottom: 0.5rem;
-    color: rgba(255, 255, 255, 0.9);
-  }
-
-  /* Day Definition */
-  .day-definition {
-    margin-bottom: 2rem;
-  }
-
-  .day-definition h3 {
-    color: #fff;
-    font-size: 1.1em;
-    margin-bottom: 1rem;
-  }
-
-  .day-definition ul {
-    padding-left: 1.5rem;
-  }
-
-  .day-definition li {
-    margin-bottom: 0.5rem;
-    color: rgba(255, 255, 255, 0.9);
-  }
-
-  /* Related Rooms */
   .related-section h3 {
     margin-bottom: 1.5rem;
     text-align: center;
@@ -420,7 +377,8 @@ const productSchema = {
     border-bottom: none;
   }
 
-  .related-card:hover {
+  .related-card:hover,
+  .related-card:focus-visible {
     transform: translateY(-5px);
   }
 
@@ -447,21 +405,9 @@ const productSchema = {
   }
 
   @media (max-width: 768px) {
-    .page-header {
-      padding: 6rem 1.5rem 2rem;
-    }
-
-    .page-header h1 {
-      font-size: 1.5rem;
-    }
-
-    .price-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    .related-grid {
-      grid-template-columns: 1fr;
-    }
+    .related-grid { grid-template-columns: 1fr; }
+    .action-buttons { flex-direction: column; }
+    .btn-action { width: 100%; }
   }
 </style>
 
@@ -477,9 +423,7 @@ const productSchema = {
 
     function updateCarousel() {
       track.style.transform = `translateX(-${currentIndex * 100}%)`;
-      dots.forEach((dot, i) => {
-        dot.classList.toggle('active', i === currentIndex);
-      });
+      dots.forEach((dot, i) => dot.classList.toggle('active', i === currentIndex));
     }
 
     prevBtn?.addEventListener('click', () => {
@@ -492,29 +436,23 @@ const productSchema = {
       updateCarousel();
     });
 
-    dots.forEach((dot, i) => {
-      dot.addEventListener('click', () => {
-        currentIndex = i;
-        updateCarousel();
-      });
-    });
+    dots.forEach((dot, i) => dot.addEventListener('click', () => {
+      currentIndex = i;
+      updateCarousel();
+    }));
 
-    // Touch support
     let touchStartX = 0;
-    track.addEventListener('touchstart', (e) => {
-      touchStartX = e.touches[0].clientX;
+    track.addEventListener('touchstart', (event) => {
+      touchStartX = event.touches[0].clientX;
     });
 
-    track.addEventListener('touchend', (e) => {
-      const diff = touchStartX - e.changedTouches[0].clientX;
-      if (Math.abs(diff) > 50) {
-        if (diff > 0) {
-          currentIndex = (currentIndex + 1) % slides.length;
-        } else {
-          currentIndex = (currentIndex - 1 + slides.length) % slides.length;
-        }
-        updateCarousel();
-      }
+    track.addEventListener('touchend', (event) => {
+      const diff = touchStartX - event.changedTouches[0].clientX;
+      if (Math.abs(diff) <= 50) return;
+      currentIndex = diff > 0
+        ? (currentIndex + 1) % slides.length
+        : (currentIndex - 1 + slides.length) % slides.length;
+      updateCarousel();
     });
   }
 </script>

--- a/astro-site/tests/booking-flow-integrity.test.ts
+++ b/astro-site/tests/booking-flow-integrity.test.ts
@@ -18,27 +18,42 @@ function normalizedContentText(path: string) {
 }
 
 describe('空房查詢與正式預訂流程', () => {
-  it('首頁 Banner 不得將 RoomCloud 誤稱為立即預訂', () => {
+  it('首頁 Banner 應只以查詢空房對外呈現', () => {
     const $ = readPage('index.html');
     const bannerBookingLink = $('#banner a[href*="roomcloud.cc"]');
+
     expect(bannerBookingLink.length).toBe(1);
     expect(bannerBookingLink.text().trim()).toBe('查詢空房');
     expect($('#banner').text()).not.toContain('立即預訂');
+    expect($('#banner').text()).not.toContain('RoomCloud');
   });
-  it('首頁應直接說明空房系統僅供查詢', () => {
+
+  it('首頁不應顯示訂房流程說明文字', () => {
     const text = normalizedText('index.html');
-    expect(text).toContain('空房系統僅供查詢');
-    expect(text).toContain('LINE 或 Facebook 聯絡確認');
+
+    expect(text).not.toContain('空房系統僅供查詢');
+    expect(text).not.toContain('LINE 或 Facebook 聯絡確認');
   });
-  it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => {
+
+  it('訂房流程頁應以線上訂房系統對外呈現', () => {
     const text = normalizedContentText('infos/account/index.html');
-    expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房');
+
+    expect(text).toContain('線上訂房系統提供目前空房查詢');
     expect(text).toContain('不會直接完成預訂');
     expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成');
+    expect(text).not.toContain('RoomCloud');
   });
+
   it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => {
     const text = normalizedContentText('infos/account/index.html');
-    const checkpoints = ['確認預計入住日期與房型是否仍有空位','透過官方管道傳訊預訂','再依通知進行匯款','請透過原先與密式旅行聯絡的管道回報匯款資訊','收到密式旅行的訂位確認後'];
+    const checkpoints = [
+      '確認預計入住日期與房型是否仍有空位',
+      '透過官方管道傳訊預訂',
+      '再依通知進行匯款',
+      '請透過原先與密式旅行聯絡的管道回報匯款資訊',
+      '收到密式旅行的訂位確認後',
+    ];
+
     let previousIndex = -1;
     checkpoints.forEach((checkpoint) => {
       const index = text.indexOf(checkpoint);
@@ -46,15 +61,19 @@ describe('空房查詢與正式預訂流程', () => {
       previousIndex = index;
     });
   });
+
   it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => {
     const text = normalizedContentText('infos/account/index.html');
+
     expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知');
     expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知');
     expect(text).not.toContain('匯款後請透過 Email 或電話回報');
   });
+
   it('官方聯絡資料應與全站設定一致', () => {
     const accountText = normalizedContentText('infos/account/index.html');
     const contactText = normalizedContentText('infos/contact-method/index.html');
+
     expect(accountText).toContain('@rys8178b');
     expect(contactText).toContain('@rys8178b');
     expect(accountText).toContain('密式旅行農場');
@@ -62,38 +81,61 @@ describe('空房查詢與正式預訂流程', () => {
     expect(accountText).not.toContain('misstravel0921 LINE');
     expect(accountText).not.toContain('line搜尋:電話號碼');
   });
+
   it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => {
     const pages = ['index.html', 'infos/account/index.html', 'infos/contact-method/index.html'];
     const officialUrl = 'https://line.me/R/ti/p/%40rys8178b';
+
     pages.forEach((file) => {
       const $ = readPage(file);
-      expect($(`a[href="${officialUrl}"]`).length, file).toBeGreaterThan(0);
+      const links = $(`a[href="${officialUrl}"]`);
+      expect(links.length, file).toBeGreaterThan(0);
     });
+
     const accountPage = readPage('infos/account/index.html');
     const contactPage = readPage('infos/contact-method/index.html');
     expect(accountPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
     expect(contactPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
+
     const qrPath = join(distDir, 'images', 'line-official-account-qr.svg');
     expect(existsSync(qrPath)).toBe(true);
-    expect(readFileSync(qrPath, 'utf-8')).toContain('@rys8178b');
+    const qrSvg = readFileSync(qrPath, 'utf-8');
+    expect(qrSvg).toContain('@rys8178b');
   });
+
   it('匯款頁應保留既有官方帳戶資料與防詐警示', () => {
     const text = normalizedContentText('infos/account/index.html');
+
     expect(text).toContain('郵局代碼：700');
     expect(text).toContain('郵局帳號：0041703-0172216');
     expect(text).toContain('匯款戶名：林季霆');
     expect(text).toContain('若有人要求改匯其他帳戶');
     expect(text).toContain('空房查詢結果不等於房位已保留');
   });
+
   it('關於密式上方導覽項目應全部為四個中文字', () => {
     const $ = readPage('infos/index.html');
-    const labels = $('.info-nav .info-link').map((_, element) => $(element).text().replace(/\s+/g, '').trim()).get();
+    const labels = $('.info-nav .info-link')
+      .map((_, element) => $(element).text().replace(/\s+/g, '').trim())
+      .get();
+
     expect(labels.length).toBe(8);
-    labels.forEach((label) => expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/));
+    labels.forEach((label) => {
+      expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/);
+    });
     expect(labels).toContain('訂房匯款');
   });
-  it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => {
-    ['index.html','rooms/index.html','rooms/campsite_1/index.html','rooms/log_cabin_1/index.html','rooms/suite_1/index.html'].forEach((file) => {
+
+  it('所有空房查詢連結的可見文字不得暗示可直接完成預訂', () => {
+    const htmlFiles = [
+      'index.html',
+      'rooms/index.html',
+      'rooms/campsite_1/index.html',
+      'rooms/log_cabin_1/index.html',
+      'rooms/suite_1/index.html',
+    ];
+
+    htmlFiles.forEach((file) => {
       const $ = readPage(file);
       $('a[href*="roomcloud.cc"]').each((_, element) => {
         const text = $(element).text().replace(/\s+/g, ' ').trim();

--- a/astro-site/tests/booking-flow-integrity.test.ts
+++ b/astro-site/tests/booking-flow-integrity.test.ts
@@ -13,41 +13,32 @@ function normalizedText(path: string) {
   return readPage(path).text().replace(/\s+/g, ' ').trim();
 }
 
+function normalizedContentText(path: string) {
+  return readPage(path)('.info-content').text().replace(/\s+/g, ' ').trim();
+}
+
 describe('空房查詢與正式預訂流程', () => {
   it('首頁 Banner 不得將 RoomCloud 誤稱為立即預訂', () => {
     const $ = readPage('index.html');
     const bannerBookingLink = $('#banner a[href*="roomcloud.cc"]');
-
     expect(bannerBookingLink.length).toBe(1);
     expect(bannerBookingLink.text().trim()).toBe('查詢空房');
     expect($('#banner').text()).not.toContain('立即預訂');
   });
-
   it('首頁應直接說明空房系統僅供查詢', () => {
     const text = normalizedText('index.html');
-
     expect(text).toContain('空房系統僅供查詢');
     expect(text).toContain('LINE 或 Facebook 聯絡確認');
   });
-
   it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => {
-    const text = normalizedText('infos/account/index.html');
-
+    const text = normalizedContentText('infos/account/index.html');
     expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房');
     expect(text).toContain('不會直接完成預訂');
     expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成');
   });
-
   it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => {
-    const text = normalizedText('infos/account/index.html');
-    const checkpoints = [
-      '確認預計入住日期與房型是否仍有空位',
-      '透過官方管道傳訊預訂',
-      '再依通知進行匯款',
-      '請透過原先與密式旅行聯絡的管道回報匯款資訊',
-      '收到密式旅行的訂位確認後',
-    ];
-
+    const text = normalizedContentText('infos/account/index.html');
+    const checkpoints = ['確認預計入住日期與房型是否仍有空位','透過官方管道傳訊預訂','再依通知進行匯款','請透過原先與密式旅行聯絡的管道回報匯款資訊','收到密式旅行的訂位確認後'];
     let previousIndex = -1;
     checkpoints.forEach((checkpoint) => {
       const index = text.indexOf(checkpoint);
@@ -55,19 +46,15 @@ describe('空房查詢與正式預訂流程', () => {
       previousIndex = index;
     });
   });
-
   it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => {
-    const text = normalizedText('infos/account/index.html');
-
+    const text = normalizedContentText('infos/account/index.html');
     expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知');
     expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知');
     expect(text).not.toContain('匯款後請透過 Email 或電話回報');
   });
-
   it('官方聯絡資料應與全站設定一致', () => {
-    const accountText = normalizedText('infos/account/index.html');
-    const contactText = normalizedText('infos/contact-method/index.html');
-
+    const accountText = normalizedContentText('infos/account/index.html');
+    const contactText = normalizedContentText('infos/contact-method/index.html');
     expect(accountText).toContain('@rys8178b');
     expect(contactText).toContain('@rys8178b');
     expect(accountText).toContain('密式旅行農場');
@@ -75,61 +62,38 @@ describe('空房查詢與正式預訂流程', () => {
     expect(accountText).not.toContain('misstravel0921 LINE');
     expect(accountText).not.toContain('line搜尋:電話號碼');
   });
-
   it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => {
     const pages = ['index.html', 'infos/account/index.html', 'infos/contact-method/index.html'];
     const officialUrl = 'https://line.me/R/ti/p/%40rys8178b';
-
     pages.forEach((file) => {
       const $ = readPage(file);
-      const links = $(`a[href="${officialUrl}"]`);
-      expect(links.length, file).toBeGreaterThan(0);
+      expect($(`a[href="${officialUrl}"]`).length, file).toBeGreaterThan(0);
     });
-
     const accountPage = readPage('infos/account/index.html');
     const contactPage = readPage('infos/contact-method/index.html');
     expect(accountPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
     expect(contactPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
-
     const qrPath = join(distDir, 'images', 'line-official-account-qr.svg');
     expect(existsSync(qrPath)).toBe(true);
-    const qrSvg = readFileSync(qrPath, 'utf-8');
-    expect(qrSvg).toContain('@rys8178b');
+    expect(readFileSync(qrPath, 'utf-8')).toContain('@rys8178b');
   });
-
   it('匯款頁應保留既有官方帳戶資料與防詐警示', () => {
-    const text = normalizedText('infos/account/index.html');
-
+    const text = normalizedContentText('infos/account/index.html');
     expect(text).toContain('郵局代碼：700');
     expect(text).toContain('郵局帳號：0041703-0172216');
     expect(text).toContain('匯款戶名：林季霆');
     expect(text).toContain('若有人要求改匯其他帳戶');
     expect(text).toContain('空房查詢結果不等於房位已保留');
   });
-
   it('關於密式上方導覽項目應全部為四個中文字', () => {
     const $ = readPage('infos/index.html');
-    const labels = $('.info-nav .info-link')
-      .map((_, element) => $(element).text().replace(/\s+/g, '').trim())
-      .get();
-
+    const labels = $('.info-nav .info-link').map((_, element) => $(element).text().replace(/\s+/g, '').trim()).get();
     expect(labels.length).toBe(8);
-    labels.forEach((label) => {
-      expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/);
-    });
+    labels.forEach((label) => expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/));
     expect(labels).toContain('訂房匯款');
   });
-
   it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => {
-    const htmlFiles = [
-      'index.html',
-      'rooms/index.html',
-      'rooms/campsite_1/index.html',
-      'rooms/log_cabin_1/index.html',
-      'rooms/suite_1/index.html',
-    ];
-
-    htmlFiles.forEach((file) => {
+    ['index.html','rooms/index.html','rooms/campsite_1/index.html','rooms/log_cabin_1/index.html','rooms/suite_1/index.html'].forEach((file) => {
       const $ = readPage(file);
       $('a[href*="roomcloud.cc"]').each((_, element) => {
         const text = $(element).text().replace(/\s+/g, ' ').trim();

--- a/astro-site/tests/room-policy-model.test.ts
+++ b/astro-site/tests/room-policy-model.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'cheerio';
+import { policiesForRoom, roomTypeFromId, selectRelatedRooms } from '../src/lib/room-policy';
+
+const distDir = join(__dirname, '..', 'dist');
+
+function page(path: string) {
+  return load(readFileSync(join(distDir, path), 'utf-8'));
+}
+
+function text(path: string) {
+  return page(path).text().replace(/\s+/g, ' ').trim();
+}
+
+describe('房型政策模型', () => {
+  it('應辨識營位、木屋與套房', () => {
+    expect(roomTypeFromId('campsite_1')).toBe('campsite');
+    expect(roomTypeFromId('log_cabin_1')).toBe('cabin');
+    expect(roomTypeFromId('suite_1')).toBe('suite');
+    expect(() => roomTypeFromId('unknown')).toThrow();
+  });
+
+  it('各類型應取得不同政策與入住時間', () => {
+    expect(policiesForRoom('campsite_1').times.checkinTime).toBe('13:00');
+    expect(policiesForRoom('suite_1').times.checkinTime).toBe('15:00');
+    expect(policiesForRoom('campsite_1').specific.join(' ')).toContain('一帳以一車四人');
+    expect(policiesForRoom('suite_1').specific.join(' ')).not.toContain('一帳');
+  });
+
+  it('套房頁不得顯示營位專屬規則', () => {
+    const suiteText = text('rooms/suite_1/index.html');
+    expect(suiteText).toContain('套房於假日及連續假期附早餐');
+    expect(suiteText).not.toContain('一帳以一車四人');
+    expect(suiteText).not.toContain('攜帶寵物離開預訂區域');
+  });
+
+  it('營位與木屋頁應顯示各自規則', () => {
+    const campsiteText = text('rooms/campsite_1/index.html');
+    const cabinText = text('rooms/log_cabin_1/index.html');
+    expect(campsiteText).toContain('一帳以一車四人');
+    expect(campsiteText).toContain('攜帶寵物離開預訂區域');
+    expect(cabinText).toContain('木屋區嚴禁攜帶寵物');
+    expect(cabinText).not.toContain('套房於假日');
+  });
+
+  it('相關房型應優先同類型與相近人數價格', () => {
+    const rooms = [
+      { id: 'campsite_1', data: { numberOfPeople: 16, weekdayPrice: 3200, order: 0 } },
+      { id: 'campsite_2', data: { numberOfPeople: 16, weekdayPrice: 3200, order: 1 } },
+      { id: 'campsite_3', data: { numberOfPeople: 8, weekdayPrice: 1600, order: 2 } },
+      { id: 'suite_1', data: { numberOfPeople: 2, weekdayPrice: 2600, order: 8 } },
+    ];
+    expect(selectRelatedRooms(rooms[0], rooms, 2).map((room) => room.id)).toEqual(['campsite_2', 'campsite_3']);
+  });
+
+  it('房型頁應輸出 Accommodation schema 與正確入住時間', () => {
+    const campsiteSchemas = page('rooms/campsite_1/index.html')('script[type="application/ld+json"]')
+      .map((_, element) => JSON.parse(page('rooms/campsite_1/index.html')(element).text()))
+      .get();
+    const suiteSchemas = page('rooms/suite_1/index.html')('script[type="application/ld+json"]')
+      .map((_, element) => JSON.parse(page('rooms/suite_1/index.html')(element).text()))
+      .get();
+
+    const campsite = campsiteSchemas.find((schema) => schema['@type'] === 'Accommodation');
+    const suite = suiteSchemas.find((schema) => schema['@type'] === 'Accommodation');
+    expect(campsite?.checkinTime).toBe('13:00');
+    expect(campsite?.accommodationCategory).toBe('露營營位');
+    expect(suite?.checkinTime).toBe('15:00');
+    expect(suite?.accommodationCategory).toBe('園區套房');
+  });
+
+  it('房型頁應提供查空房與 LINE 入口', () => {
+    const $ = page('rooms/campsite_1/index.html');
+    expect($('a[href*="roomcloud.cc"]').text()).toContain('查詢空房');
+    expect($('a[href="https://line.me/R/ti/p/%40rys8178b"]').text()).toContain('LINE 詢問');
+  });
+});


### PR DESCRIPTION
## 變更摘要

- 建立集中式房型政策模型，自動辨識營位、露營木屋與套房
- 將共通規則與房型專屬規則分離
  - 套房不再顯示「一帳一車」與營位寵物規則
  - 木屋不再顯示套房早餐規則
  - 營位保留帳數、寵物繫繩與架高炊煮規則
- 將訪客規則整理成「17:00 後不再入場、已入場者 20:00 前離開」
- 房型頁改用 Accommodation 結構化資料，依類型輸出入住時間與住宿類別
- 相關房型推薦改為優先同類型、相近人數與相近價格
- 房型頁增加「查詢空房」與「LINE 詢問」直接入口
- 新增房型政策、推薦演算法與結構化資料對抗測試

## 根本原因

原房型模板把營位、木屋與套房的規則混在同一份清單中，導致套房頁出現帳篷規則、木屋頁出現套房早餐等不相干資訊；相關房型則只依固定排序取前三筆，沒有真正的相關性。

## 對抗審查

- 三種房型必須能被穩定分類
- 套房頁不得出現營位專屬規則
- 木屋與營位必須保留各自必要政策
- Accommodation schema 必須依房型輸出正確類別與入住時間
- 相關推薦必須優先同類型
- 查空房與 LINE 入口必須存在且使用官方連結

## 驗收

等待 GitHub Actions CI 與 Vercel Preview 完成。