### PR TITLE
統一 Modal、Lightbox 與輪播無障礙行為

### DIFF
--- a/astro-site/public/scripts/interaction-accessibility.js
+++ b/astro-site/public/scripts/interaction-accessibility.js
@@ -1,0 +1,180 @@
+(() => {
+  const FOCUSABLE = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+
+  let activeDialog = null;
+  let returnFocus = null;
+
+  function focusableElements(dialog) {
+    return [...dialog.querySelectorAll(FOCUSABLE)].filter((element) => {
+      return !element.hasAttribute('hidden') && element.getAttribute('aria-hidden') !== 'true';
+    });
+  }
+
+  function activateDialog(dialog, trigger) {
+    if (!(dialog instanceof HTMLElement)) return;
+    returnFocus = trigger instanceof HTMLElement ? trigger : document.activeElement;
+    activeDialog = dialog;
+    dialog.setAttribute('aria-hidden', 'false');
+    dialog.querySelectorAll('.modal-close, .lightbox-close').forEach((button) => {
+      if (!button.getAttribute('aria-label')) button.setAttribute('aria-label', '關閉對話框');
+    });
+    requestAnimationFrame(() => {
+      const focusables = focusableElements(dialog);
+      (focusables[0] || dialog).focus({ preventScroll: true });
+    });
+  }
+
+  function deactivateDialog(dialog) {
+    if (!(dialog instanceof HTMLElement)) return;
+    dialog.setAttribute('aria-hidden', 'true');
+    if (activeDialog === dialog) activeDialog = null;
+    if (returnFocus instanceof HTMLElement && document.contains(returnFocus)) {
+      returnFocus.focus({ preventScroll: true });
+    }
+    returnFocus = null;
+  }
+
+  function currentlyOpenDialog() {
+    return document.querySelector('.modal.active, .lightbox-overlay.active');
+  }
+
+  document.querySelectorAll('.modal, .lightbox-overlay').forEach((dialog) => {
+    dialog.setAttribute('aria-hidden', dialog.classList.contains('active') ? 'false' : 'true');
+    if (!dialog.hasAttribute('tabindex')) dialog.setAttribute('tabindex', '-1');
+  });
+
+  document.addEventListener('click', (event) => {
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target) return;
+
+    const modalTrigger = target.closest('[data-modal]');
+    if (modalTrigger) {
+      const modalId = modalTrigger.getAttribute('data-modal');
+      const dialog = modalId ? document.getElementById(modalId) : null;
+      if (dialog) setTimeout(() => activateDialog(dialog, modalTrigger), 0);
+      return;
+    }
+
+    const lightboxTrigger = target.closest('[data-lightbox]');
+    if (lightboxTrigger) {
+      setTimeout(() => {
+        const dialog = currentlyOpenDialog();
+        if (dialog) activateDialog(dialog, lightboxTrigger);
+      }, 0);
+      return;
+    }
+
+    const closeControl = target.closest('.modal-close, .lightbox-close');
+    if (closeControl) {
+      const dialog = closeControl.closest('.modal, .lightbox-overlay');
+      if (dialog) setTimeout(() => deactivateDialog(dialog), 0);
+    }
+  });
+
+  const dialogObserver = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      const dialog = mutation.target;
+      if (!(dialog instanceof HTMLElement)) return;
+      if (dialog.classList.contains('active')) {
+        if (activeDialog !== dialog) activateDialog(dialog, returnFocus);
+      } else if (dialog.getAttribute('aria-hidden') !== 'true') {
+        deactivateDialog(dialog);
+      }
+    });
+  });
+
+  document.querySelectorAll('.modal, .lightbox-overlay').forEach((dialog) => {
+    dialogObserver.observe(dialog, { attributes: true, attributeFilter: ['class'] });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    const dialog = activeDialog || currentlyOpenDialog();
+    if (!(dialog instanceof HTMLElement)) return;
+
+    if (event.key === 'Escape') {
+      setTimeout(() => deactivateDialog(dialog), 0);
+      return;
+    }
+
+    if (event.key !== 'Tab') return;
+    const focusables = focusableElements(dialog);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+
+  function enhanceCarousel(carousel) {
+    if (!(carousel instanceof HTMLElement) || carousel.dataset.a11yReady === 'true') return;
+    carousel.dataset.a11yReady = 'true';
+    carousel.setAttribute('role', 'region');
+    carousel.setAttribute('aria-roledescription', '輪播');
+    if (!carousel.getAttribute('aria-label')) carousel.setAttribute('aria-label', '圖片輪播');
+
+    const slides = [...carousel.querySelectorAll('.carousel-slide, .carousel-item')];
+    const controls = [...carousel.querySelectorAll('.dot, .indicator')];
+
+    function currentIndex() {
+      const activeSlide = slides.findIndex((slide) => slide.classList.contains('active'));
+      if (activeSlide >= 0) return activeSlide;
+      const activeControl = controls.findIndex((control) => control.classList.contains('active'));
+      return Math.max(activeControl, 0);
+    }
+
+    function sync() {
+      const index = currentIndex();
+      slides.forEach((slide, slideIndex) => {
+        slide.setAttribute('role', 'group');
+        slide.setAttribute('aria-roledescription', '投影片');
+        slide.setAttribute('aria-label', `第 ${slideIndex + 1} 張，共 ${slides.length} 張`);
+        slide.setAttribute('aria-hidden', slideIndex === index ? 'false' : 'true');
+      });
+      controls.forEach((control, controlIndex) => {
+        if (control instanceof HTMLElement && control.tagName === 'SPAN') {
+          control.setAttribute('role', 'button');
+          control.setAttribute('tabindex', '0');
+        }
+        control.setAttribute('aria-label', `顯示第 ${controlIndex + 1} 張圖片`);
+        control.setAttribute('aria-current', controlIndex === index ? 'true' : 'false');
+      });
+    }
+
+    carousel.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        carousel.querySelector('.prev, .carousel-prev, .lightbox-prev')?.click();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        carousel.querySelector('.next, .carousel-next, .lightbox-next')?.click();
+      } else if ((event.key === 'Enter' || event.key === ' ') && event.target instanceof HTMLElement && event.target.matches('.indicator')) {
+        event.preventDefault();
+        event.target.click();
+      }
+      setTimeout(sync, 0);
+    });
+
+    carousel.addEventListener('click', () => setTimeout(sync, 0));
+    new MutationObserver(sync).observe(carousel, { attributes: true, subtree: true, attributeFilter: ['class', 'style'] });
+    sync();
+  }
+
+  document.querySelectorAll('.carousel').forEach(enhanceCarousel);
+})();

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import Head from '../components/SEO/Head.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
+import '../styles/interaction-accessibility.css';
 
 interface ArticleMeta {
   publishedTime: string;
@@ -65,5 +66,6 @@ const {
 
       <Footer />
     </div>
+    <script is:inline src="/scripts/interaction-accessibility.js" defer></script>
   </body>
 </html>

--- a/astro-site/src/styles/interaction-accessibility.css
+++ b/astro-site/src/styles/interaction-accessibility.css
@@ -1,0 +1,39 @@
+.modal[aria-hidden='true'],
+.lightbox-overlay[aria-hidden='true'] {
+  pointer-events: none;
+}
+
+.modal-close:focus-visible,
+.lightbox-close:focus-visible,
+.lightbox-nav:focus-visible,
+.carousel-btn:focus-visible,
+.dot:focus-visible,
+.indicator:focus-visible,
+.guide-btn:focus-visible,
+.sale-btn:focus-visible {
+  outline: 3px solid #9bf1ff;
+  outline-offset: 3px;
+}
+
+.indicator[role='button'] {
+  border: 2px solid transparent;
+}
+
+.indicator[aria-current='true'] {
+  border-color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/astro-site/tests/booking-flow-integrity.test.ts
+++ b/astro-site/tests/booking-flow-integrity.test.ts
@@ -4,31 +4,143 @@ import { join } from 'node:path';
 import { load } from 'cheerio';
 
 const distDir = join(__dirname, '..', 'dist');
-function readPage(path: string) { return load(readFileSync(join(distDir, path), 'utf-8')); }
-function normalizedText(path: string) { return readPage(path).text().replace(/\s+/g, ' ').trim(); }
-function normalizedContentText(path: string) { return readPage(path)('.info-content').text().replace(/\s+/g, ' ').trim(); }
+
+function readPage(path: string) {
+  return load(readFileSync(join(distDir, path), 'utf-8'));
+}
+
+function normalizedText(path: string) {
+  return readPage(path).text().replace(/\s+/g, ' ').trim();
+}
+
+function normalizedContentText(path: string) {
+  return readPage(path)('.info-content').text().replace(/\s+/g, ' ').trim();
+}
 
 describe('空房查詢與正式預訂流程', () => {
-  it('首頁 Banner 不得將 RoomCloud 誤稱為立即預訂', () => {
+  it('首頁 Banner 應只以查詢空房對外呈現', () => {
     const $ = readPage('index.html');
-    const link = $('#banner a[href*="roomcloud.cc"]');
-    expect(link.length).toBe(1); expect(link.text().trim()).toBe('查詢空房'); expect($('#banner').text()).not.toContain('立即預訂');
+    const bannerBookingLink = $('#banner a[href*="roomcloud.cc"]');
+
+    expect(bannerBookingLink.length).toBe(1);
+    expect(bannerBookingLink.text().trim()).toBe('查詢空房');
+    expect($('#banner').text()).not.toContain('立即預訂');
+    expect($('#banner').text()).not.toContain('RoomCloud');
   });
-  it('首頁應直接說明空房系統僅供查詢', () => { const text = normalizedText('index.html'); expect(text).toContain('空房系統僅供查詢'); expect(text).toContain('LINE 或 Facebook 聯絡確認'); });
-  it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房'); expect(text).toContain('不會直接完成預訂'); expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成'); });
+
+  it('首頁不應顯示訂房流程說明文字', () => {
+    const text = normalizedText('index.html');
+
+    expect(text).not.toContain('空房系統僅供查詢');
+    expect(text).not.toContain('LINE 或 Facebook 聯絡確認');
+  });
+
+  it('訂房流程頁應以線上訂房系統對外呈現', () => {
+    const text = normalizedContentText('infos/account/index.html');
+
+    expect(text).toContain('線上訂房系統提供目前空房查詢');
+    expect(text).toContain('不會直接完成預訂');
+    expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成');
+    expect(text).not.toContain('RoomCloud');
+  });
+
   it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => {
     const text = normalizedContentText('infos/account/index.html');
-    const checkpoints = ['確認預計入住日期與房型是否仍有空位','透過官方管道傳訊預訂','再依通知進行匯款','請透過原先與密式旅行聯絡的管道回報匯款資訊','收到密式旅行的訂位確認後'];
-    let previousIndex = -1; checkpoints.forEach((checkpoint) => { const index = text.indexOf(checkpoint); expect(index, checkpoint).toBeGreaterThan(previousIndex); previousIndex = index; });
+    const checkpoints = [
+      '確認預計入住日期與房型是否仍有空位',
+      '透過官方管道傳訊預訂',
+      '再依通知進行匯款',
+      '請透過原先與密式旅行聯絡的管道回報匯款資訊',
+      '收到密式旅行的訂位確認後',
+    ];
+
+    let previousIndex = -1;
+    checkpoints.forEach((checkpoint) => {
+      const index = text.indexOf(checkpoint);
+      expect(index, checkpoint).toBeGreaterThan(previousIndex);
+      previousIndex = index;
+    });
   });
-  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知'); expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知'); expect(text).not.toContain('匯款後請透過 Email 或電話回報'); });
-  it('官方聯絡資料應與全站設定一致', () => { const account = normalizedContentText('infos/account/index.html'); const contact = normalizedContentText('infos/contact-method/index.html'); expect(account).toContain('@rys8178b'); expect(contact).toContain('@rys8178b'); expect(account).toContain('密式旅行農場'); expect(account).toContain('0905-108-958'); expect(account).not.toContain('misstravel0921 LINE'); expect(account).not.toContain('line搜尋:電話號碼'); });
+
+  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => {
+    const text = normalizedContentText('infos/account/index.html');
+
+    expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知');
+    expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知');
+    expect(text).not.toContain('匯款後請透過 Email 或電話回報');
+  });
+
+  it('官方聯絡資料應與全站設定一致', () => {
+    const accountText = normalizedContentText('infos/account/index.html');
+    const contactText = normalizedContentText('infos/contact-method/index.html');
+
+    expect(accountText).toContain('@rys8178b');
+    expect(contactText).toContain('@rys8178b');
+    expect(accountText).toContain('密式旅行農場');
+    expect(accountText).toContain('0905-108-958');
+    expect(accountText).not.toContain('misstravel0921 LINE');
+    expect(accountText).not.toContain('line搜尋:電話號碼');
+  });
+
   it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => {
-    const officialUrl = 'https://line.me/R/ti/p/%40rys8178b'; ['index.html','infos/account/index.html','infos/contact-method/index.html'].forEach((file) => expect(readPage(file)(`a[href="${officialUrl}"]`).length, file).toBeGreaterThan(0));
-    expect(readPage('infos/account/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1); expect(readPage('infos/contact-method/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
-    const qrPath = join(distDir, 'images', 'line-official-account-qr.svg'); expect(existsSync(qrPath)).toBe(true); expect(readFileSync(qrPath, 'utf-8')).toContain('@rys8178b');
+    const pages = ['index.html', 'infos/account/index.html', 'infos/contact-method/index.html'];
+    const officialUrl = 'https://line.me/R/ti/p/%40rys8178b';
+
+    pages.forEach((file) => {
+      const $ = readPage(file);
+      const links = $(`a[href="${officialUrl}"]`);
+      expect(links.length, file).toBeGreaterThan(0);
+    });
+
+    const accountPage = readPage('infos/account/index.html');
+    const contactPage = readPage('infos/contact-method/index.html');
+    expect(accountPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
+    expect(contactPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
+
+    const qrPath = join(distDir, 'images', 'line-official-account-qr.svg');
+    expect(existsSync(qrPath)).toBe(true);
+    const qrSvg = readFileSync(qrPath, 'utf-8');
+    expect(qrSvg).toContain('@rys8178b');
   });
-  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('郵局代碼：700'); expect(text).toContain('郵局帳號：0041703-0172216'); expect(text).toContain('匯款戶名：林季霆'); expect(text).toContain('若有人要求改匯其他帳戶'); expect(text).toContain('空房查詢結果不等於房位已保留'); });
-  it('關於密式上方導覽項目應全部為四個中文字', () => { const $ = readPage('infos/index.html'); const labels = $('.info-nav .info-link').map((_, element) => $(element).text().replace(/\s+/g, '').trim()).get(); expect(labels.length).toBe(8); labels.forEach((label) => expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/)); expect(labels).toContain('訂房匯款'); });
-  it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => { ['index.html','rooms/index.html','rooms/campsite_1/index.html','rooms/log_cabin_1/index.html','rooms/suite_1/index.html'].forEach((file) => { const $ = readPage(file); $('a[href*="roomcloud.cc"]').each((_, element) => { const text = $(element).text().replace(/\s+/g, ' ').trim(); expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/); }); }); });
+
+  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => {
+    const text = normalizedContentText('infos/account/index.html');
+
+    expect(text).toContain('郵局代碼：700');
+    expect(text).toContain('郵局帳號：0041703-0172216');
+    expect(text).toContain('匯款戶名：林季霆');
+    expect(text).toContain('若有人要求改匯其他帳戶');
+    expect(text).toContain('空房查詢結果不等於房位已保留');
+  });
+
+  it('關於密式上方導覽項目應全部為四個中文字', () => {
+    const $ = readPage('infos/index.html');
+    const labels = $('.info-nav .info-link')
+      .map((_, element) => $(element).text().replace(/\s+/g, '').trim())
+      .get();
+
+    expect(labels.length).toBe(8);
+    labels.forEach((label) => {
+      expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/);
+    });
+    expect(labels).toContain('訂房匯款');
+  });
+
+  it('所有空房查詢連結的可見文字不得暗示可直接完成預訂', () => {
+    const htmlFiles = [
+      'index.html',
+      'rooms/index.html',
+      'rooms/campsite_1/index.html',
+      'rooms/log_cabin_1/index.html',
+      'rooms/suite_1/index.html',
+    ];
+
+    htmlFiles.forEach((file) => {
+      const $ = readPage(file);
+      $('a[href*="roomcloud.cc"]').each((_, element) => {
+        const text = $(element).text().replace(/\s+/g, ' ').trim();
+        expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/);
+      });
+    });
+  });
 });

--- a/astro-site/tests/booking-flow-integrity.test.ts
+++ b/astro-site/tests/booking-flow-integrity.test.ts
@@ -4,137 +4,31 @@ import { join } from 'node:path';
 import { load } from 'cheerio';
 
 const distDir = join(__dirname, '..', 'dist');
-
-function readPage(path: string) {
-  return load(readFileSync(join(distDir, path), 'utf-8'));
-}
-
-function normalizedText(path: string) {
-  return readPage(path).text().replace(/\s+/g, ' ').trim();
-}
+function readPage(path: string) { return load(readFileSync(join(distDir, path), 'utf-8')); }
+function normalizedText(path: string) { return readPage(path).text().replace(/\s+/g, ' ').trim(); }
+function normalizedContentText(path: string) { return readPage(path)('.info-content').text().replace(/\s+/g, ' ').trim(); }
 
 describe('空房查詢與正式預訂流程', () => {
   it('首頁 Banner 不得將 RoomCloud 誤稱為立即預訂', () => {
     const $ = readPage('index.html');
-    const bannerBookingLink = $('#banner a[href*="roomcloud.cc"]');
-
-    expect(bannerBookingLink.length).toBe(1);
-    expect(bannerBookingLink.text().trim()).toBe('查詢空房');
-    expect($('#banner').text()).not.toContain('立即預訂');
+    const link = $('#banner a[href*="roomcloud.cc"]');
+    expect(link.length).toBe(1); expect(link.text().trim()).toBe('查詢空房'); expect($('#banner').text()).not.toContain('立即預訂');
   });
-
-  it('首頁應直接說明空房系統僅供查詢', () => {
-    const text = normalizedText('index.html');
-
-    expect(text).toContain('空房系統僅供查詢');
-    expect(text).toContain('LINE 或 Facebook 聯絡確認');
-  });
-
-  it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => {
-    const text = normalizedText('infos/account/index.html');
-
-    expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房');
-    expect(text).toContain('不會直接完成預訂');
-    expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成');
-  });
-
+  it('首頁應直接說明空房系統僅供查詢', () => { const text = normalizedText('index.html'); expect(text).toContain('空房系統僅供查詢'); expect(text).toContain('LINE 或 Facebook 聯絡確認'); });
+  it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房'); expect(text).toContain('不會直接完成預訂'); expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成'); });
   it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => {
-    const text = normalizedText('infos/account/index.html');
-    const checkpoints = [
-      '確認預計入住日期與房型是否仍有空位',
-      '透過官方管道傳訊預訂',
-      '再依通知進行匯款',
-      '請透過原先與密式旅行聯絡的管道回報匯款資訊',
-      '收到密式旅行的訂位確認後',
-    ];
-
-    let previousIndex = -1;
-    checkpoints.forEach((checkpoint) => {
-      const index = text.indexOf(checkpoint);
-      expect(index, checkpoint).toBeGreaterThan(previousIndex);
-      previousIndex = index;
-    });
+    const text = normalizedContentText('infos/account/index.html');
+    const checkpoints = ['確認預計入住日期與房型是否仍有空位','透過官方管道傳訊預訂','再依通知進行匯款','請透過原先與密式旅行聯絡的管道回報匯款資訊','收到密式旅行的訂位確認後'];
+    let previousIndex = -1; checkpoints.forEach((checkpoint) => { const index = text.indexOf(checkpoint); expect(index, checkpoint).toBeGreaterThan(previousIndex); previousIndex = index; });
   });
-
-  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => {
-    const text = normalizedText('infos/account/index.html');
-
-    expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知');
-    expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知');
-    expect(text).not.toContain('匯款後請透過 Email 或電話回報');
-  });
-
-  it('官方聯絡資料應與全站設定一致', () => {
-    const accountText = normalizedText('infos/account/index.html');
-    const contactText = normalizedText('infos/contact-method/index.html');
-
-    expect(accountText).toContain('@rys8178b');
-    expect(contactText).toContain('@rys8178b');
-    expect(accountText).toContain('密式旅行農場');
-    expect(accountText).toContain('0905-108-958');
-    expect(accountText).not.toContain('misstravel0921 LINE');
-    expect(accountText).not.toContain('line搜尋:電話號碼');
-  });
-
+  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知'); expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知'); expect(text).not.toContain('匯款後請透過 Email 或電話回報'); });
+  it('官方聯絡資料應與全站設定一致', () => { const account = normalizedContentText('infos/account/index.html'); const contact = normalizedContentText('infos/contact-method/index.html'); expect(account).toContain('@rys8178b'); expect(contact).toContain('@rys8178b'); expect(account).toContain('密式旅行農場'); expect(account).toContain('0905-108-958'); expect(account).not.toContain('misstravel0921 LINE'); expect(account).not.toContain('line搜尋:電話號碼'); });
   it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => {
-    const pages = ['index.html', 'infos/account/index.html', 'infos/contact-method/index.html'];
-    const officialUrl = 'https://line.me/R/ti/p/%40rys8178b';
-
-    pages.forEach((file) => {
-      const $ = readPage(file);
-      const links = $(`a[href="${officialUrl}"]`);
-      expect(links.length, file).toBeGreaterThan(0);
-    });
-
-    const accountPage = readPage('infos/account/index.html');
-    const contactPage = readPage('infos/contact-method/index.html');
-    expect(accountPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
-    expect(contactPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
-
-    const qrPath = join(distDir, 'images', 'line-official-account-qr.svg');
-    expect(existsSync(qrPath)).toBe(true);
-    const qrSvg = readFileSync(qrPath, 'utf-8');
-    expect(qrSvg).toContain('@rys8178b');
+    const officialUrl = 'https://line.me/R/ti/p/%40rys8178b'; ['index.html','infos/account/index.html','infos/contact-method/index.html'].forEach((file) => expect(readPage(file)(`a[href="${officialUrl}"]`).length, file).toBeGreaterThan(0));
+    expect(readPage('infos/account/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1); expect(readPage('infos/contact-method/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
+    const qrPath = join(distDir, 'images', 'line-official-account-qr.svg'); expect(existsSync(qrPath)).toBe(true); expect(readFileSync(qrPath, 'utf-8')).toContain('@rys8178b');
   });
-
-  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => {
-    const text = normalizedText('infos/account/index.html');
-
-    expect(text).toContain('郵局代碼：700');
-    expect(text).toContain('郵局帳號：0041703-0172216');
-    expect(text).toContain('匯款戶名：林季霆');
-    expect(text).toContain('若有人要求改匯其他帳戶');
-    expect(text).toContain('空房查詢結果不等於房位已保留');
-  });
-
-  it('關於密式上方導覽項目應全部為四個中文字', () => {
-    const $ = readPage('infos/index.html');
-    const labels = $('.info-nav .info-link')
-      .map((_, element) => $(element).text().replace(/\s+/g, '').trim())
-      .get();
-
-    expect(labels.length).toBe(8);
-    labels.forEach((label) => {
-      expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/);
-    });
-    expect(labels).toContain('訂房匯款');
-  });
-
-  it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => {
-    const htmlFiles = [
-      'index.html',
-      'rooms/index.html',
-      'rooms/campsite_1/index.html',
-      'rooms/log_cabin_1/index.html',
-      'rooms/suite_1/index.html',
-    ];
-
-    htmlFiles.forEach((file) => {
-      const $ = readPage(file);
-      $('a[href*="roomcloud.cc"]').each((_, element) => {
-        const text = $(element).text().replace(/\s+/g, ' ').trim();
-        expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/);
-      });
-    });
-  });
+  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('郵局代碼：700'); expect(text).toContain('郵局帳號：0041703-0172216'); expect(text).toContain('匯款戶名：林季霆'); expect(text).toContain('若有人要求改匯其他帳戶'); expect(text).toContain('空房查詢結果不等於房位已保留'); });
+  it('關於密式上方導覽項目應全部為四個中文字', () => { const $ = readPage('infos/index.html'); const labels = $('.info-nav .info-link').map((_, element) => $(element).text().replace(/\s+/g, '').trim()).get(); expect(labels.length).toBe(8); labels.forEach((label) => expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/)); expect(labels).toContain('訂房匯款'); });
+  it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => { ['index.html','rooms/index.html','rooms/campsite_1/index.html','rooms/log_cabin_1/index.html','rooms/suite_1/index.html'].forEach((file) => { const $ = readPage(file); $('a[href*="roomcloud.cc"]').each((_, element) => { const text = $(element).text().replace(/\s+/g, ' ').trim(); expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/); }); }); });
 });

--- a/astro-site/tests/interaction-accessibility.test.ts
+++ b/astro-site/tests/interaction-accessibility.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'cheerio';
+
+const projectDir = join(__dirname, '..');
+const distDir = join(projectDir, 'dist');
+
+function page(path: string) {
+  return load(readFileSync(join(distDir, path), 'utf-8'));
+}
+
+describe('共用互動無障礙控制器', () => {
+  it('所有代表頁面都應載入共用控制器', () => {
+    [
+      'infos/guide/index.html',
+      'galleries/index.html',
+      'sale_items/index.html',
+      'rooms/campsite_1/index.html',
+    ].forEach((path) => {
+      const $ = page(path);
+      expect($('script[src="/scripts/interaction-accessibility.js"]').length, path).toBe(1);
+    });
+  });
+
+  it('所有 Modal 與 Lightbox 應具備 dialog 語意', () => {
+    const pages = ['infos/guide/index.html', 'galleries/index.html', 'sale_items/index.html'];
+    pages.forEach((path) => {
+      const $ = page(path);
+      $('.modal, .lightbox-overlay').each((_, element) => {
+        expect($(element).attr('role'), path).toBe('dialog');
+        expect($(element).attr('aria-modal'), path).toBe('true');
+      });
+    });
+  });
+
+  it('控制器應處理焦點移入、Tab 鎖定、Escape 與焦點返回', () => {
+    const controller = readFileSync(join(projectDir, 'public', 'scripts', 'interaction-accessibility.js'), 'utf-8');
+    expect(controller).toContain('focusableElements');
+    expect(controller).toContain("event.key !== 'Tab'");
+    expect(controller).toContain("event.key === 'Escape'");
+    expect(controller).toContain('returnFocus.focus');
+    expect(controller).toContain("aria-hidden");
+  });
+
+  it('輪播應具有鍵盤方向鍵與 ARIA 狀態同步', () => {
+    const controller = readFileSync(join(projectDir, 'public', 'scripts', 'interaction-accessibility.js'), 'utf-8');
+    expect(controller).toContain("event.key === 'ArrowLeft'");
+    expect(controller).toContain("event.key === 'ArrowRight'");
+    expect(controller).toContain("aria-current");
+    expect(controller).toContain("aria-roledescription");
+    expect(controller).toContain("aria-hidden");
+  });
+
+  it('應尊重 reduced motion 並提供清楚焦點樣式', () => {
+    const css = readFileSync(join(projectDir, 'src', 'styles', 'interaction-accessibility.css'), 'utf-8');
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain(':focus-visible');
+    expect(css).toContain('outline: 3px solid');
+  });
+});


### PR DESCRIPTION
## 變更摘要

- 新增全站共用互動無障礙控制器
- 統一交通指南、圖集與柑仔店對話框行為
  - 開啟後焦點移入
  - Tab 焦點限制於對話框內
  - Escape 關閉
  - 關閉後焦點返回原按鈕或圖片
  - 同步 `aria-hidden`
- 自動補齊沒有名稱的關閉按鈕
- 為房型與柑仔店輪播補上
  - 左右方向鍵操作
  - 投影片角色、順序與總數
  - `aria-hidden`、`aria-current`
  - 既有 span 指示點的鍵盤操作
- 新增明確焦點樣式與 reduced-motion 支援
- 新增互動無障礙回歸測試

## 根本原因

現有三套 Modal／Lightbox 與兩套輪播各自維護，只處理滑鼠點擊與部分 Escape 行為；鍵盤焦點可能跑到背景頁面，關閉後也不會回到原觸發位置。靜態 HTML 測試無法覆蓋這些共通行為。

## 對抗審查

- 代表頁面必須載入同一個共用控制器
- Dialog 必須保留 `role="dialog"` 與 `aria-modal="true"`
- 控制器必須具備焦點移入、Tab 鎖定、Escape 與焦點返回
- 輪播必須同步投影片與控制器 ARIA 狀態
- 動畫必須尊重 reduced-motion

## 驗收

等待 GitHub Actions CI 與 Vercel Preview 完成。