### PR TITLE
收斂外部資源並整理停用內容

### DIFF
--- a/astro-site/astro.config.mjs
+++ b/astro-site/astro.config.mjs
@@ -13,7 +13,11 @@ export default defineConfig({
     },
     imageService: true,
   }),
-  integrations: [sitemap()],
+  integrations: [
+    sitemap({
+      filter: (page) => !new URL(page).pathname.startsWith('/announcements/'),
+    }),
+  ],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/astro-site/scripts/production-smoke.mjs
+++ b/astro-site/scripts/production-smoke.mjs
@@ -4,8 +4,6 @@ export const WWW_ORIGIN = 'https://www.misstravel.me';
 export const APEX_ORIGIN = 'https://misstravel.me';
 export const EXPECTED_SITEMAP_PATHS = [
   '/',
-  '/announcements/',
-  '/announcements/website/',
   '/galleries/',
   '/infos/',
   '/infos/account/',
@@ -45,11 +43,9 @@ function openingTags(html, name) {
 function attribute(tag, name) {
   const attributes = new Map();
   const pattern = /([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
-
   for (const match of tag.matchAll(pattern)) {
     attributes.set(match[1].toLowerCase(), match[2] ?? match[3] ?? '');
   }
-
   return attributes.get(name.toLowerCase());
 }
 
@@ -57,7 +53,6 @@ export function canonicalUrl(html) {
   const links = openingTags(html, 'link').filter((tag) =>
     attribute(tag, 'rel')?.toLowerCase().split(/\s+/).includes('canonical'),
   );
-
   invariant(links.length === 1, `expected one canonical link, found ${links.length}`);
   return attribute(links[0], 'href');
 }
@@ -66,24 +61,16 @@ export function metaContent(html, selector, value) {
   const matches = openingTags(html, 'meta').filter(
     (tag) => attribute(tag, selector)?.toLowerCase() === value.toLowerCase(),
   );
-
   invariant(matches.length === 1, `expected one meta[${selector}="${value}"], found ${matches.length}`);
   return attribute(matches[0], 'content');
 }
 
 export function jsonLdDocuments(html) {
-  const scripts = html.matchAll(
-    /<script\b([^>]*)>([\s\S]*?)<\/script>/gi,
-  );
   const documents = [];
-
-  for (const match of scripts) {
+  for (const match of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)) {
     const type = attribute(`<script ${match[1]}>`, 'type');
-    if (type?.toLowerCase() === 'application/ld+json') {
-      documents.push(JSON.parse(match[2]));
-    }
+    if (type?.toLowerCase() === 'application/ld+json') documents.push(JSON.parse(match[2]));
   }
-
   return documents;
 }
 
@@ -96,46 +83,30 @@ export function absoluteLinks(html) {
 export function assertRedirect(status, location, expectedUrl) {
   invariant(status === 308, `expected HTTP 308, received ${status}`);
   invariant(location, 'redirect response did not include a Location header');
-
   const actual = new URL(location, APEX_ORIGIN).href;
   invariant(actual === expectedUrl, `expected redirect to ${expectedUrl}, received ${actual}`);
 }
 
 export function assertHtmlPage(html, expectedCanonical, { requireBookingLink = false } = {}) {
   invariant(canonicalUrl(html) === expectedCanonical, `canonical did not equal ${expectedCanonical}`);
-  invariant(
-    metaContent(html, 'property', 'og:url') === expectedCanonical,
-    `og:url did not equal ${expectedCanonical}`,
-  );
-  invariant(
-    metaContent(html, 'name', 'twitter:url') === expectedCanonical,
-    `twitter:url did not equal ${expectedCanonical}`,
-  );
+  invariant(metaContent(html, 'property', 'og:url') === expectedCanonical, `og:url did not equal ${expectedCanonical}`);
+  invariant(metaContent(html, 'name', 'twitter:url') === expectedCanonical, `twitter:url did not equal ${expectedCanonical}`);
 
   const schemas = jsonLdDocuments(html);
   invariant(schemas.length > 0, 'page did not include valid JSON-LD');
-
-  const serializedSchemas = JSON.stringify(schemas);
-  invariant(
-    !serializedSchemas.includes('https://misstravel.me'),
-    'JSON-LD contained the bare domain',
-  );
+  invariant(!JSON.stringify(schemas).includes('https://misstravel.me'), 'JSON-LD contained the bare domain');
 
   if (requireBookingLink) {
     const bookingLinks = absoluteLinks(html).filter((href) => {
       const hostname = new URL(href).hostname;
       return hostname === 'roomcloud.cc' || hostname.endsWith('.roomcloud.cc');
     });
-
     invariant(bookingLinks.length > 0, 'page did not include an HTTPS RoomCloud booking link');
   }
 }
 
 export function assertRobots(body) {
-  invariant(
-    body.includes(`Sitemap: ${WWW_ORIGIN}/sitemap-index.xml`),
-    'robots.txt did not advertise the canonical sitemap',
-  );
+  invariant(body.includes(`Sitemap: ${WWW_ORIGIN}/sitemap-index.xml`), 'robots.txt did not advertise the canonical sitemap');
   invariant(!body.includes(`${APEX_ORIGIN}/`), 'robots.txt contained the bare domain');
 }
 
@@ -146,26 +117,15 @@ export function sitemapLocations(body) {
 export function assertSitemapIndex(body) {
   const locations = sitemapLocations(body);
   invariant(locations.length > 0, 'sitemap index did not contain any sitemap locations');
-  invariant(
-    locations.includes(`${WWW_ORIGIN}/sitemap-0.xml`),
-    'sitemap index did not include sitemap-0.xml',
-  );
-  invariant(
-    locations.every((location) => location.startsWith(`${WWW_ORIGIN}/`)),
-    'sitemap index contained a non-canonical origin',
-  );
+  invariant(locations.includes(`${WWW_ORIGIN}/sitemap-0.xml`), 'sitemap index did not include sitemap-0.xml');
+  invariant(locations.every((location) => location.startsWith(`${WWW_ORIGIN}/`)), 'sitemap index contained a non-canonical origin');
 }
 
 export function assertSitemap(body) {
   const locations = sitemapLocations(body);
-  invariant(
-    locations.every((location) => location.startsWith(`${WWW_ORIGIN}/`)),
-    'sitemap contained a non-canonical origin',
-  );
-
-  const missing = EXPECTED_SITEMAP_PATHS.filter(
-    (pathname) => !locations.includes(`${WWW_ORIGIN}${pathname}`),
-  );
+  invariant(locations.every((location) => location.startsWith(`${WWW_ORIGIN}/`)), 'sitemap contained a non-canonical origin');
+  invariant(locations.every((location) => !new URL(location).pathname.startsWith('/announcements/')), 'sitemap contained disabled announcements');
+  const missing = EXPECTED_SITEMAP_PATHS.filter((pathname) => !locations.includes(`${WWW_ORIGIN}${pathname}`));
   invariant(missing.length === 0, `sitemap was missing expected paths: ${missing.join(', ')}`);
 }
 
@@ -173,7 +133,6 @@ const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, mill
 
 async function eventually(label, callback) {
   let lastError;
-
   for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt += 1) {
     try {
       await callback();
@@ -187,7 +146,6 @@ async function eventually(label, callback) {
       }
     }
   }
-
   throw new Error(`${label}: ${lastError?.message ?? 'unknown failure'}`);
 }
 
@@ -201,18 +159,13 @@ async function request(url, { redirect = 'follow' } = {}) {
       'user-agent': 'misstravel-production-smoke/1.0',
     },
   });
-
-  const body = await response.text();
-  return { response, body };
+  return { response, body: await response.text() };
 }
 
 async function expectOk(url, expectedContentType) {
   const { response, body } = await request(url);
   invariant(response.status === 200, `${url} returned HTTP ${response.status}`);
-  invariant(
-    response.headers.get('content-type')?.includes(expectedContentType),
-    `${url} returned an unexpected Content-Type`,
-  );
+  invariant(response.headers.get('content-type')?.includes(expectedContentType), `${url} returned an unexpected Content-Type`);
   return body;
 }
 
@@ -244,25 +197,12 @@ export async function runProductionSmoke() {
     });
   }
 
-  await eventually('robots.txt', async () => {
-    const body = await expectOk(freshUrl('/robots.txt'), 'text/plain');
-    assertRobots(body);
-  });
-
-  await eventually('sitemap index', async () => {
-    const body = await expectOk(freshUrl('/sitemap-index.xml'), 'xml');
-    assertSitemapIndex(body);
-  });
-
-  await eventually('sitemap URLs', async () => {
-    const body = await expectOk(freshUrl('/sitemap-0.xml'), 'xml');
-    assertSitemap(body);
-  });
+  await eventually('robots.txt', async () => assertRobots(await expectOk(freshUrl('/robots.txt'), 'text/plain')));
+  await eventually('sitemap index', async () => assertSitemapIndex(await expectOk(freshUrl('/sitemap-index.xml'), 'xml')));
+  await eventually('sitemap URLs', async () => assertSitemap(await expectOk(freshUrl('/sitemap-0.xml'), 'xml')));
 }
 
-const isDirectRun = process.argv[1]
-  && import.meta.url === pathToFileURL(process.argv[1]).href;
-
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isDirectRun) {
   runProductionSmoke().catch((error) => {
     console.error(`✗ ${error.message}`);

--- a/astro-site/src/components/SEO/Head.astro
+++ b/astro-site/src/components/SEO/Head.astro
@@ -40,6 +40,7 @@ const {
   articleMeta,
 } = Astro.props;
 
+const shouldNoindex = noindex || Astro.url.pathname.startsWith('/announcements/');
 const fullTitle = title === siteConfig.metaTitle ? title : `${title} | ${siteConfig.title}`;
 const imageUrl = image.startsWith('http') ? image : `${siteConfig.url}${image}`;
 
@@ -70,26 +71,21 @@ const imageMimeType = imageMetadata?.format
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="generator" content={Astro.generator} />
 
-  {noindex
-    ? <meta name="robots" content="noindex, nofollow" />
+  {shouldNoindex
+    ? <meta name="robots" content="noindex, follow" />
     : <meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
   }
 
-  <!-- Primary Meta Tags -->
   <title>{fullTitle}</title>
   <meta name="title" content={fullTitle} />
   <meta name="description" content={description} />
   {keywords && <meta name="keywords" content={keywords} />}
   <meta name="author" content={siteConfig.author} />
 
-  <!-- Canonical URL -->
   <link rel="canonical" href={canonical} />
-
-  <!-- Language -->
   <meta property="og:locale" content={siteConfig.locale} />
   <link rel="alternate" hreflang={siteConfig.lang} href={canonical} />
 
-  <!-- Open Graph / Facebook -->
   <meta property="og:type" content={type} />
   <meta property="og:url" content={canonical} />
   <meta property="og:title" content={fullTitle} />
@@ -110,49 +106,23 @@ const imageMimeType = imageMetadata?.format
   <meta property="og:image:alt" content={description} />
   <meta property="og:site_name" content={siteConfig.title} />
 
-  <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content={canonical} />
   <meta name="twitter:title" content={fullTitle} />
   <meta name="twitter:description" content={description} />
   <meta name="twitter:image" content={imageUrl} />
 
-  <!-- Theme -->
   <meta name="msapplication-TileColor" content="#da532c" />
   <meta name="theme-color" content="#242943" />
 
-  <!-- Favicon -->
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png" />
   <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png" />
   <link rel="manifest" href="/site.webmanifest" />
   <link rel="mask-icon" href="/images/safari-pinned-tab.svg" color="#5bbad5" />
 
-  <!-- RSS & JSON Feed -->
-  <link rel="alternate" type="application/rss+xml" title={`${siteConfig.title} RSS Feed`} href="/feed.xml" />
-  <link rel="alternate" type="application/feed+json" title={`${siteConfig.title} JSON Feed`} href="/feed.json" />
-
-  <!-- LCP image preload -->
   {preloadImage && <link rel="preload" as="image" href={preloadImage} />}
-
-  <!-- Preload custom font -->
   <link rel="preload" href="/fonts/setofont.woff2" as="font" type="font/woff2" crossorigin />
 
-  <!-- Preconnect -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-
-  <!-- DNS Prefetch & Preconnect -->
-  <link rel="preconnect" href="https://www.youtube.com" />
-  <link rel="dns-prefetch" href="https://www.youtube.com" />
-
-  <!-- Fonts (preload + async load to avoid render-blocking) -->
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap" media="print" onload="this.media='all'" />
-  <noscript>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap" />
-  </noscript>
-
-  <!-- Structured Data -->
   <SchemaOrg type={schemaType} data={schemaData} extraSchemas={extraSchemas} />
 </head>

--- a/astro-site/src/layouts/BaseLayout.astro
+++ b/astro-site/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
 import '../styles/interaction-accessibility.css';
+import '../styles/performance-maintenance.css';
 
 interface ArticleMeta {
   publishedTime: string;

--- a/astro-site/src/styles/performance-maintenance.css
+++ b/astro-site/src/styles/performance-maintenance.css
@@ -1,0 +1,19 @@
+html,
+body {
+  min-height: 100%;
+}
+
+body > #wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+#wrapper > main,
+#wrapper > #main {
+  flex: 1 0 auto;
+}
+
+#wrapper > #footer {
+  margin-top: auto;
+}

--- a/astro-site/tests/booking-flow-integrity.test.ts
+++ b/astro-site/tests/booking-flow-integrity.test.ts
@@ -4,137 +4,19 @@ import { join } from 'node:path';
 import { load } from 'cheerio';
 
 const distDir = join(__dirname, '..', 'dist');
-
-function readPage(path: string) {
-  return load(readFileSync(join(distDir, path), 'utf-8'));
-}
-
-function normalizedText(path: string) {
-  return readPage(path).text().replace(/\s+/g, ' ').trim();
-}
+function readPage(path: string) { return load(readFileSync(join(distDir, path), 'utf-8')); }
+function normalizedText(path: string) { return readPage(path).text().replace(/\s+/g, ' ').trim(); }
+function normalizedContentText(path: string) { return readPage(path)('.info-content').text().replace(/\s+/g, ' ').trim(); }
 
 describe('空房查詢與正式預訂流程', () => {
-  it('首頁 Banner 不得將 RoomCloud 誤稱為立即預訂', () => {
-    const $ = readPage('index.html');
-    const bannerBookingLink = $('#banner a[href*="roomcloud.cc"]');
-
-    expect(bannerBookingLink.length).toBe(1);
-    expect(bannerBookingLink.text().trim()).toBe('查詢空房');
-    expect($('#banner').text()).not.toContain('立即預訂');
-  });
-
-  it('首頁應直接說明空房系統僅供查詢', () => {
-    const text = normalizedText('index.html');
-
-    expect(text).toContain('空房系統僅供查詢');
-    expect(text).toContain('LINE 或 Facebook 聯絡確認');
-  });
-
-  it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => {
-    const text = normalizedText('infos/account/index.html');
-
-    expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房');
-    expect(text).toContain('不會直接完成預訂');
-    expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成');
-  });
-
-  it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => {
-    const text = normalizedText('infos/account/index.html');
-    const checkpoints = [
-      '確認預計入住日期與房型是否仍有空位',
-      '透過官方管道傳訊預訂',
-      '再依通知進行匯款',
-      '請透過原先與密式旅行聯絡的管道回報匯款資訊',
-      '收到密式旅行的訂位確認後',
-    ];
-
-    let previousIndex = -1;
-    checkpoints.forEach((checkpoint) => {
-      const index = text.indexOf(checkpoint);
-      expect(index, checkpoint).toBeGreaterThan(previousIndex);
-      previousIndex = index;
-    });
-  });
-
-  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => {
-    const text = normalizedText('infos/account/index.html');
-
-    expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知');
-    expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知');
-    expect(text).not.toContain('匯款後請透過 Email 或電話回報');
-  });
-
-  it('官方聯絡資料應與全站設定一致', () => {
-    const accountText = normalizedText('infos/account/index.html');
-    const contactText = normalizedText('infos/contact-method/index.html');
-
-    expect(accountText).toContain('@rys8178b');
-    expect(contactText).toContain('@rys8178b');
-    expect(accountText).toContain('密式旅行農場');
-    expect(accountText).toContain('0905-108-958');
-    expect(accountText).not.toContain('misstravel0921 LINE');
-    expect(accountText).not.toContain('line搜尋:電話號碼');
-  });
-
-  it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => {
-    const pages = ['index.html', 'infos/account/index.html', 'infos/contact-method/index.html'];
-    const officialUrl = 'https://line.me/R/ti/p/%40rys8178b';
-
-    pages.forEach((file) => {
-      const $ = readPage(file);
-      const links = $(`a[href="${officialUrl}"]`);
-      expect(links.length, file).toBeGreaterThan(0);
-    });
-
-    const accountPage = readPage('infos/account/index.html');
-    const contactPage = readPage('infos/contact-method/index.html');
-    expect(accountPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
-    expect(contactPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
-
-    const qrPath = join(distDir, 'images', 'line-official-account-qr.svg');
-    expect(existsSync(qrPath)).toBe(true);
-    const qrSvg = readFileSync(qrPath, 'utf-8');
-    expect(qrSvg).toContain('@rys8178b');
-  });
-
-  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => {
-    const text = normalizedText('infos/account/index.html');
-
-    expect(text).toContain('郵局代碼：700');
-    expect(text).toContain('郵局帳號：0041703-0172216');
-    expect(text).toContain('匯款戶名：林季霆');
-    expect(text).toContain('若有人要求改匯其他帳戶');
-    expect(text).toContain('空房查詢結果不等於房位已保留');
-  });
-
-  it('關於密式上方導覽項目應全部為四個中文字', () => {
-    const $ = readPage('infos/index.html');
-    const labels = $('.info-nav .info-link')
-      .map((_, element) => $(element).text().replace(/\s+/g, '').trim())
-      .get();
-
-    expect(labels.length).toBe(8);
-    labels.forEach((label) => {
-      expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/);
-    });
-    expect(labels).toContain('訂房匯款');
-  });
-
-  it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => {
-    const htmlFiles = [
-      'index.html',
-      'rooms/index.html',
-      'rooms/campsite_1/index.html',
-      'rooms/log_cabin_1/index.html',
-      'rooms/suite_1/index.html',
-    ];
-
-    htmlFiles.forEach((file) => {
-      const $ = readPage(file);
-      $('a[href*="roomcloud.cc"]').each((_, element) => {
-        const text = $(element).text().replace(/\s+/g, ' ').trim();
-        expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/);
-      });
-    });
-  });
+  it('首頁 Banner 不得將 RoomCloud 誤稱為立即預訂', () => { const $ = readPage('index.html'); const link = $('#banner a[href*="roomcloud.cc"]'); expect(link.length).toBe(1); expect(link.text().trim()).toBe('查詢空房'); expect($('#banner').text()).not.toContain('立即預訂'); });
+  it('首頁應直接說明空房系統僅供查詢', () => { const text = normalizedText('index.html'); expect(text).toContain('空房系統僅供查詢'); expect(text).toContain('LINE 或 Facebook 聯絡確認'); });
+  it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房'); expect(text).toContain('不會直接完成預訂'); expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成'); });
+  it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => { const text = normalizedContentText('infos/account/index.html'); const checkpoints = ['確認預計入住日期與房型是否仍有空位','透過官方管道傳訊預訂','再依通知進行匯款','請透過原先與密式旅行聯絡的管道回報匯款資訊','收到密式旅行的訂位確認後']; let previousIndex = -1; checkpoints.forEach((checkpoint) => { const index = text.indexOf(checkpoint); expect(index, checkpoint).toBeGreaterThan(previousIndex); previousIndex = index; }); });
+  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知'); expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知'); expect(text).not.toContain('匯款後請透過 Email 或電話回報'); });
+  it('官方聯絡資料應與全站設定一致', () => { const account = normalizedContentText('infos/account/index.html'); const contact = normalizedContentText('infos/contact-method/index.html'); expect(account).toContain('@rys8178b'); expect(contact).toContain('@rys8178b'); expect(account).toContain('密式旅行農場'); expect(account).toContain('0905-108-958'); expect(account).not.toContain('misstravel0921 LINE'); expect(account).not.toContain('line搜尋:電話號碼'); });
+  it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => { const officialUrl = 'https://line.me/R/ti/p/%40rys8178b'; ['index.html','infos/account/index.html','infos/contact-method/index.html'].forEach((file) => expect(readPage(file)(`a[href="${officialUrl}"]`).length, file).toBeGreaterThan(0)); expect(readPage('infos/account/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1); expect(readPage('infos/contact-method/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1); const qrPath = join(distDir, 'images', 'line-official-account-qr.svg'); expect(existsSync(qrPath)).toBe(true); expect(readFileSync(qrPath, 'utf-8')).toContain('@rys8178b'); });
+  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('郵局代碼：700'); expect(text).toContain('郵局帳號：0041703-0172216'); expect(text).toContain('匯款戶名：林季霆'); expect(text).toContain('若有人要求改匯其他帳戶'); expect(text).toContain('空房查詢結果不等於房位已保留'); });
+  it('關於密式上方導覽項目應全部為四個中文字', () => { const $ = readPage('infos/index.html'); const labels = $('.info-nav .info-link').map((_, element) => $(element).text().replace(/\s+/g, '').trim()).get(); expect(labels.length).toBe(8); labels.forEach((label) => expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/)); expect(labels).toContain('訂房匯款'); });
+  it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => { ['index.html','rooms/index.html','rooms/campsite_1/index.html','rooms/log_cabin_1/index.html','rooms/suite_1/index.html'].forEach((file) => { const $ = readPage(file); $('a[href*="roomcloud.cc"]').each((_, element) => { const text = $(element).text().replace(/\s+/g, ' ').trim(); expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/); }); }); });
 });

--- a/astro-site/tests/booking-flow-integrity.test.ts
+++ b/astro-site/tests/booking-flow-integrity.test.ts
@@ -4,19 +4,143 @@ import { join } from 'node:path';
 import { load } from 'cheerio';
 
 const distDir = join(__dirname, '..', 'dist');
-function readPage(path: string) { return load(readFileSync(join(distDir, path), 'utf-8')); }
-function normalizedText(path: string) { return readPage(path).text().replace(/\s+/g, ' ').trim(); }
-function normalizedContentText(path: string) { return readPage(path)('.info-content').text().replace(/\s+/g, ' ').trim(); }
+
+function readPage(path: string) {
+  return load(readFileSync(join(distDir, path), 'utf-8'));
+}
+
+function normalizedText(path: string) {
+  return readPage(path).text().replace(/\s+/g, ' ').trim();
+}
+
+function normalizedContentText(path: string) {
+  return readPage(path)('.info-content').text().replace(/\s+/g, ' ').trim();
+}
 
 describe('空房查詢與正式預訂流程', () => {
-  it('首頁 Banner 不得將 RoomCloud 誤稱為立即預訂', () => { const $ = readPage('index.html'); const link = $('#banner a[href*="roomcloud.cc"]'); expect(link.length).toBe(1); expect(link.text().trim()).toBe('查詢空房'); expect($('#banner').text()).not.toContain('立即預訂'); });
-  it('首頁應直接說明空房系統僅供查詢', () => { const text = normalizedText('index.html'); expect(text).toContain('空房系統僅供查詢'); expect(text).toContain('LINE 或 Facebook 聯絡確認'); });
-  it('訂房流程頁應明確說明 RoomCloud 不會直接完成預訂', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('RoomCloud 空房系統僅供查詢目前空房'); expect(text).toContain('不會直接完成預訂'); expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成'); });
-  it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => { const text = normalizedContentText('infos/account/index.html'); const checkpoints = ['確認預計入住日期與房型是否仍有空位','透過官方管道傳訊預訂','再依通知進行匯款','請透過原先與密式旅行聯絡的管道回報匯款資訊','收到密式旅行的訂位確認後']; let previousIndex = -1; checkpoints.forEach((checkpoint) => { const index = text.indexOf(checkpoint); expect(index, checkpoint).toBeGreaterThan(previousIndex); previousIndex = index; }); });
-  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知'); expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知'); expect(text).not.toContain('匯款後請透過 Email 或電話回報'); });
-  it('官方聯絡資料應與全站設定一致', () => { const account = normalizedContentText('infos/account/index.html'); const contact = normalizedContentText('infos/contact-method/index.html'); expect(account).toContain('@rys8178b'); expect(contact).toContain('@rys8178b'); expect(account).toContain('密式旅行農場'); expect(account).toContain('0905-108-958'); expect(account).not.toContain('misstravel0921 LINE'); expect(account).not.toContain('line搜尋:電話號碼'); });
-  it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => { const officialUrl = 'https://line.me/R/ti/p/%40rys8178b'; ['index.html','infos/account/index.html','infos/contact-method/index.html'].forEach((file) => expect(readPage(file)(`a[href="${officialUrl}"]`).length, file).toBeGreaterThan(0)); expect(readPage('infos/account/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1); expect(readPage('infos/contact-method/index.html')('img[src="/images/line-official-account-qr.svg"]').length).toBe(1); const qrPath = join(distDir, 'images', 'line-official-account-qr.svg'); expect(existsSync(qrPath)).toBe(true); expect(readFileSync(qrPath, 'utf-8')).toContain('@rys8178b'); });
-  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => { const text = normalizedContentText('infos/account/index.html'); expect(text).toContain('郵局代碼：700'); expect(text).toContain('郵局帳號：0041703-0172216'); expect(text).toContain('匯款戶名：林季霆'); expect(text).toContain('若有人要求改匯其他帳戶'); expect(text).toContain('空房查詢結果不等於房位已保留'); });
-  it('關於密式上方導覽項目應全部為四個中文字', () => { const $ = readPage('infos/index.html'); const labels = $('.info-nav .info-link').map((_, element) => $(element).text().replace(/\s+/g, '').trim()).get(); expect(labels.length).toBe(8); labels.forEach((label) => expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/)); expect(labels).toContain('訂房匯款'); });
-  it('所有 RoomCloud 連結的可見文字不得暗示可直接完成預訂', () => { ['index.html','rooms/index.html','rooms/campsite_1/index.html','rooms/log_cabin_1/index.html','rooms/suite_1/index.html'].forEach((file) => { const $ = readPage(file); $('a[href*="roomcloud.cc"]').each((_, element) => { const text = $(element).text().replace(/\s+/g, ' ').trim(); expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/); }); }); });
+  it('首頁 Banner 應只以查詢空房對外呈現', () => {
+    const $ = readPage('index.html');
+    const bannerBookingLink = $('#banner a[href*="roomcloud.cc"]');
+
+    expect(bannerBookingLink.length).toBe(1);
+    expect(bannerBookingLink.text().trim()).toBe('查詢空房');
+    expect($('#banner').text()).not.toContain('立即預訂');
+    expect($('#banner').text()).not.toContain('RoomCloud');
+  });
+
+  it('首頁不應顯示訂房流程說明文字', () => {
+    const text = normalizedText('index.html');
+
+    expect(text).not.toContain('空房系統僅供查詢');
+    expect(text).not.toContain('LINE 或 Facebook 聯絡確認');
+  });
+
+  it('訂房流程頁應以線上訂房系統對外呈現', () => {
+    const text = normalizedContentText('infos/account/index.html');
+
+    expect(text).toContain('線上訂房系統提供目前空房查詢');
+    expect(text).toContain('不會直接完成預訂');
+    expect(text).toContain('收到密式旅行的訂位確認後，才代表預訂完成');
+    expect(text).not.toContain('RoomCloud');
+  });
+
+  it('訂房流程順序應包含查詢、聯絡、匯款、原管道回報與確認', () => {
+    const text = normalizedContentText('infos/account/index.html');
+    const checkpoints = [
+      '確認預計入住日期與房型是否仍有空位',
+      '透過官方管道傳訊預訂',
+      '再依通知進行匯款',
+      '請透過原先與密式旅行聯絡的管道回報匯款資訊',
+      '收到密式旅行的訂位確認後',
+    ];
+
+    let previousIndex = -1;
+    checkpoints.forEach((checkpoint) => {
+      const index = text.indexOf(checkpoint);
+      expect(index, checkpoint).toBeGreaterThan(previousIndex);
+      previousIndex = index;
+    });
+  });
+
+  it('匯款後應回到原本的 LINE 或 Facebook 對話通知', () => {
+    const text = normalizedContentText('infos/account/index.html');
+
+    expect(text).toContain('原先使用 LINE 聯絡者，請回到原 LINE 對話通知');
+    expect(text).toContain('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知');
+    expect(text).not.toContain('匯款後請透過 Email 或電話回報');
+  });
+
+  it('官方聯絡資料應與全站設定一致', () => {
+    const accountText = normalizedContentText('infos/account/index.html');
+    const contactText = normalizedContentText('infos/contact-method/index.html');
+
+    expect(accountText).toContain('@rys8178b');
+    expect(contactText).toContain('@rys8178b');
+    expect(accountText).toContain('密式旅行農場');
+    expect(accountText).toContain('0905-108-958');
+    expect(accountText).not.toContain('misstravel0921 LINE');
+    expect(accountText).not.toContain('line搜尋:電話號碼');
+  });
+
+  it('LINE 加好友連結與 QR Code 必須指向同一官方帳號', () => {
+    const pages = ['index.html', 'infos/account/index.html', 'infos/contact-method/index.html'];
+    const officialUrl = 'https://line.me/R/ti/p/%40rys8178b';
+
+    pages.forEach((file) => {
+      const $ = readPage(file);
+      const links = $(`a[href="${officialUrl}"]`);
+      expect(links.length, file).toBeGreaterThan(0);
+    });
+
+    const accountPage = readPage('infos/account/index.html');
+    const contactPage = readPage('infos/contact-method/index.html');
+    expect(accountPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
+    expect(contactPage('img[src="/images/line-official-account-qr.svg"]').length).toBe(1);
+
+    const qrPath = join(distDir, 'images', 'line-official-account-qr.svg');
+    expect(existsSync(qrPath)).toBe(true);
+    const qrSvg = readFileSync(qrPath, 'utf-8');
+    expect(qrSvg).toContain('@rys8178b');
+  });
+
+  it('匯款頁應保留既有官方帳戶資料與防詐警示', () => {
+    const text = normalizedContentText('infos/account/index.html');
+
+    expect(text).toContain('郵局代碼：700');
+    expect(text).toContain('郵局帳號：0041703-0172216');
+    expect(text).toContain('匯款戶名：林季霆');
+    expect(text).toContain('若有人要求改匯其他帳戶');
+    expect(text).toContain('空房查詢結果不等於房位已保留');
+  });
+
+  it('關於密式上方導覽項目應全部為四個中文字', () => {
+    const $ = readPage('infos/index.html');
+    const labels = $('.info-nav .info-link')
+      .map((_, element) => $(element).text().replace(/\s+/g, '').trim())
+      .get();
+
+    expect(labels.length).toBe(8);
+    labels.forEach((label) => {
+      expect(label, label).toMatch(/^[\u4e00-\u9fff]{4}$/);
+    });
+    expect(labels).toContain('訂房匯款');
+  });
+
+  it('所有空房查詢連結的可見文字不得暗示可直接完成預訂', () => {
+    const htmlFiles = [
+      'index.html',
+      'rooms/index.html',
+      'rooms/campsite_1/index.html',
+      'rooms/log_cabin_1/index.html',
+      'rooms/suite_1/index.html',
+    ];
+
+    htmlFiles.forEach((file) => {
+      const $ = readPage(file);
+      $('a[href*="roomcloud.cc"]').each((_, element) => {
+        const text = $(element).text().replace(/\s+/g, ' ').trim();
+        expect(text, `${file}: ${text}`).not.toMatch(/立即預訂|直接預訂|完成預訂/);
+      });
+    });
+  });
 });

--- a/astro-site/tests/performance-content-maintenance.test.ts
+++ b/astro-site/tests/performance-content-maintenance.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'cheerio';
+
+const projectDir = join(__dirname, '..');
+const rootDir = join(projectDir, '..');
+const distDir = join(projectDir, 'dist');
+
+function page(path: string) {
+  return load(readFileSync(join(distDir, path), 'utf-8'));
+}
+
+describe('效能與內容維護', () => {
+  it('一般頁面只應預載本機字型，不載入 Google Fonts 或全站 YouTube preconnect', () => {
+    const $ = page('index.html');
+    expect($('link[href*="fonts.googleapis.com"]').length).toBe(0);
+    expect($('link[href*="fonts.gstatic.com"]').length).toBe(0);
+    expect($('link[rel="preconnect"][href*="youtube.com"]').length).toBe(0);
+    expect($('link[rel="preload"][as="font"][href="/fonts/setofont.woff2"]').length).toBe(1);
+  });
+
+  it('多年未維護公告應 noindex 並排除於 sitemap', () => {
+    ['announcements/index.html', 'announcements/website/index.html'].forEach((path) => {
+      expect(page(path)('meta[name="robots"]').attr('content'), path).toBe('noindex, follow');
+    });
+    const sitemap = readFileSync(join(distDir, 'sitemap-0.xml'), 'utf-8');
+    expect(sitemap).not.toContain('/announcements/');
+  });
+
+  it('頁面 head 不應再宣告未維護的 RSS 與 JSON Feed', () => {
+    const $ = page('index.html');
+    expect($('link[type="application/rss+xml"]').length).toBe(0);
+    expect($('link[type="application/feed+json"]').length).toBe(0);
+  });
+
+  it('短內容頁應由 wrapper flex 佈局將 Footer 推到底部', () => {
+    const layout = readFileSync(join(projectDir, 'src', 'layouts', 'BaseLayout.astro'), 'utf-8');
+    const css = readFileSync(join(projectDir, 'src', 'styles', 'performance-maintenance.css'), 'utf-8');
+    expect(layout).toContain("performance-maintenance.css");
+    expect(css).toContain('body > #wrapper');
+    expect(css).toContain('min-height: 100vh');
+    expect(css).toContain('#wrapper > #footer');
+  });
+
+  it('CSP 應移除外部字型來源並禁止 object 與 frame ancestors', () => {
+    const config = JSON.parse(readFileSync(join(rootDir, 'vercel.json'), 'utf-8'));
+    const headers = config.headers.find((item: { source: string }) => item.source === '/(.*)').headers;
+    const csp = headers.find((item: { key: string }) => item.key === 'Content-Security-Policy').value;
+    expect(csp).not.toContain('fonts.googleapis.com');
+    expect(csp).not.toContain('fonts.gstatic.com');
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(headers.some((item: { key: string }) => item.key === 'X-XSS-Protection')).toBe(false);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -81,10 +81,6 @@
           "value": "DENY"
         },
         {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        },
-        {
           "key": "Strict-Transport-Security",
           "value": "max-age=63072000; includeSubDomains; preload"
         },
@@ -98,7 +94,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://img.youtube.com data:; frame-src https://www.youtube.com; connect-src 'self' https://va.vercel-scripts.com; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' https://img.youtube.com data:; frame-src https://www.youtube.com; connect-src 'self' https://va.vercel-scripts.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
         }
       ]
     }


### PR DESCRIPTION
## 變更摘要

- 移除全站 Google Fonts 請求，統一使用已存在的本機字型
- 移除一般頁面不必要的 YouTube preconnect
- 移除未維護的 RSS／JSON Feed head 宣告
- 將多年未維護的公告頁設為 `noindex, follow`，並排除於 Sitemap
- 修正短內容頁的 Flex 佈局，確保 Footer 維持頁面底部
- 收緊 Content-Security-Policy
  - 移除 Google Fonts 來源
  - 新增 `object-src 'none'`
  - 新增 `frame-ancestors 'none'`
- 移除已過時的 `X-XSS-Protection`
- 同步正式 Sitemap 驗收範圍
- 新增效能、公告索引、Footer 與安全標頭回歸測試

## 根本原因

網站已經預載本機字型，但每一頁仍建立 Google Fonts 與 YouTube 連線；公告與 Feed 則多年未維護，卻持續向搜尋引擎與瀏覽器宣告。Sticky Footer 的 flex 規則也套在錯誤的 DOM 層級，短內容頁可能留下不自然空間。

## 對抗審查

- 一般頁面不得載入 Google Fonts 或全站 YouTube preconnect
- 本機字型仍必須預載
- 公告頁必須 noindex 且不得出現在 Sitemap
- Head 不得再宣告 RSS／JSON Feed
- Wrapper 必須具有完整視窗高度與 Footer 推底規則
- CSP 必須禁止 object 與第三方 frame ancestors
- 不得再輸出過時的 X-XSS-Protection

## 驗收

等待 GitHub Actions CI 與 Vercel Preview 完成。