### PR TITLE
驗證正式站實際輸出

### DIFF
--- a/.github/workflows/production-live-verification.yml
+++ b/.github/workflows/production-live-verification.yml
@@ -1,0 +1,25 @@
+name: Production Live Verification
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-production:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out latest main verification scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Verify production canonical metadata
+        run: node astro-site/scripts/production-smoke.mjs
+
+      - name: Verify production routes, booking schema and security headers
+        run: node astro-site/scripts/production-route-smoke.mjs


### PR DESCRIPTION
僅用來從 GitHub Actions 對公開 Production domain 執行實際 HTTP smoke，不合併。驗證首頁、訂房頁、Schema、安全標頭、Sitemap 與舊網址 308 轉址。