### PR TITLE
恢復 Vercel 完整驗證 gate

### DIFF
--- a/astro-site/tests/seo-round8.test.ts
+++ b/astro-site/tests/seo-round8.test.ts
@@ -70,7 +70,7 @@ describe('3. og:image 尺寸', () => {
   });
 });
 
-// 4. 唯一正式網域與部署責任分離
+// 4. 唯一正式網域
 describe('4. 正式網域一致性', () => {
   it('canonical 與 Open Graph URL 應使用 www 主網域', () => {
     const $ = readPage('index.html');
@@ -98,14 +98,12 @@ describe('4. 正式網域一致性', () => {
     expect(redirect.has).toContainEqual({ type: 'host', value: 'misstravel.me' });
   });
 
-  it('Vercel 應使用鎖檔安裝並只負責建置，完整驗證由 GitHub CI 執行', () => {
-    const rootDir = join(distDir, '..', '..');
-    const config = JSON.parse(readFileSync(join(rootDir, 'vercel.json'), 'utf-8'));
-    const workflow = readFileSync(join(rootDir, '.github', 'workflows', 'ci.yml'), 'utf-8');
-
+  it('Vercel 部署應使用鎖檔安裝並通過完整測試', () => {
+    const config = JSON.parse(
+      readFileSync(join(distDir, '..', '..', 'vercel.json'), 'utf-8')
+    );
     expect(config.installCommand).toBe('cd astro-site && npm ci');
-    expect(config.buildCommand).toBe('cd astro-site && npm run build');
-    expect(workflow).toContain('run: npm run verify');
+    expect(config.buildCommand).toBe('cd astro-site && npm run verify');
   });
 });
 
@@ -137,6 +135,7 @@ describe('6. 相關房型 alt 文字', () => {
     expect(imgs.length).toBeGreaterThan(0);
     imgs.each((_, el) => {
       const alt = $(el).attr('alt') || '';
+      // alt 應不只是短標題，至少要有 "住宿" 相關描述
       expect(alt.length).toBeGreaterThan(3);
       expect(alt).toMatch(/住宿|外觀|營區/);
     });

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "astro",
   "installCommand": "cd astro-site && npm ci",
-  "buildCommand": "cd astro-site && npm run build",
+  "buildCommand": "cd astro-site && npm run verify",
   "outputDirectory": "astro-site/dist",
   "redirects": [
     {


### PR DESCRIPTION
## 變更摘要

- 將 Vercel `buildCommand` 從 `npm run build` 恢復為 `npm run verify`
- 恢復對應回歸測試，確保未來 Vercel 部署前仍需通過 audit、typecheck、Astro build 與完整 Vitest

## 原因

PR #34 的核心 `js-yaml 4.3.1` 安全修正已有效，`npm audit` 回到 0 vulnerabilities；但驗證過程中暫時將 Vercel 改成只 build 的設定先被合併。這會降低 production deployment gate，因此恢復先前的完整驗證策略。

## 明確不變

- 不修改任何頁面文字或營運內容
- 不回退 js-yaml 安全修正
- 不修改 Production Smoke 強化
- 不修改 Sitemap、Feed、訂房與房型內容

## 驗收

- GitHub CI 全部通過
- Vercel Preview 必須成功完成 `npm run verify`
- `npm audit --audit-level=high` 必須為 0 vulnerabilities