### PR TITLE
修正 Production Smoke 訂房原文比對

### DIFF
--- a/astro-site/scripts/production-route-smoke.mjs
+++ b/astro-site/scripts/production-route-smoke.mjs
@@ -83,7 +83,9 @@ export async function verifyBookingPresentation(origin = WWW_ORIGIN) {
   const accountHtml = await accountResponse.text();
   invariant(accountHtml.includes('線上訂房系統提供目前空房查詢'), 'booking page did not use the public online booking system name');
   invariant(!accountHtml.includes('RoomCloud'), 'booking page exposed the booking vendor name');
-  invariant(accountHtml.includes('回到原本的 LINE 或 Facebook 對話通知'), 'booking page did not preserve the original contact channel');
+  invariant(accountHtml.includes('匯款後，請透過原先與密式旅行聯絡的管道回報匯款資訊'), 'booking page did not preserve the approved payment reporting instruction');
+  invariant(accountHtml.includes('原先使用 LINE 聯絡者，請回到原 LINE 對話通知'), 'booking page did not preserve the LINE reporting channel');
+  invariant(accountHtml.includes('原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知'), 'booking page did not preserve the Facebook reporting channel');
   invariant(!accountHtml.includes('匯款後請來電或來信確認'), 'booking page still contained the old payment callback instruction');
   invariant(!accountHtml.includes('"@type":"FAQPage"'), 'booking page still published the stale FAQPage schema');
 


### PR DESCRIPTION
## 變更摘要

只修正正式站驗收腳本，不修改任何網站內容。

Production Smoke 原本要求一個頁面不存在的合併句「回到原本的 LINE 或 Facebook 對話通知」，造成正式站誤報失敗。

現在改為逐字驗證目前核准且實際存在的三段原文：

- 匯款後，請透過原先與密式旅行聯絡的管道回報匯款資訊
- 原先使用 LINE 聯絡者，請回到原 LINE 對話通知
- 原先使用 Facebook 聯絡者，請回到原 Facebook Messenger 對話通知

其他正式站驗收保持不變，包括 Sitemap、11 個舊網址 308、Schema 與安全標頭。