### PR TITLE
建立房型三分類內容模型

### DIFF
--- a/astro-site/src/content.config.ts
+++ b/astro-site/src/content.config.ts
@@ -29,7 +29,7 @@ const rooms = defineCollection({
     numberOfRooms: z.number(),
     numberOfPeople: z.number(),
     order: z.number(),
-    isCampsite: z.boolean().default(false),
+    category: z.enum(['campsite', 'cabin', 'suite']),
     mainImage: z.string(),
     images: z.array(z.string()).default([]),
   }),

--- a/astro-site/src/content/rooms/campsite_1.md
+++ b/astro-site/src/content/rooms/campsite_1.md
@@ -25,7 +25,7 @@ priceOptions:
 numberOfRooms: 1
 numberOfPeople: 16
 order: 0
-isCampsite: true
+category: 'campsite'
 keywords: '櫻花之盡, 木棧板露營, 包區露營, 苗栗露營, 泰安露營, 密式旅行, 16人露營, 3帳包區, 4帳包區, 依帳數計價, 2400-4800元, 木平台露營, 家族露營, 團體露營, 櫻花露營區'
 mainImage: '/images/campsite_1_main.webp'
 images:

--- a/astro-site/src/content/rooms/campsite_2.md
+++ b/astro-site/src/content/rooms/campsite_2.md
@@ -25,7 +25,7 @@ priceOptions:
 numberOfRooms: 1
 numberOfPeople: 16
 order: 1
-isCampsite: true
+category: 'campsite'
 keywords: '沒日之嶺, 草地露營, 包區露營, 苗栗露營, 泰安露營, 密式旅行, 16人露營, 3帳包區, 4帳包區, 依帳數計價, 2400-4800元, 草地營位, 家族露營, 團體露營, 山景露營'
 mainImage: '/images/campsite_2_main.webp'
 images:

--- a/astro-site/src/content/rooms/campsite_3.md
+++ b/astro-site/src/content/rooms/campsite_3.md
@@ -10,7 +10,7 @@ weekdayPrice: 1600
 numberOfRooms: 1
 numberOfPeople: 8
 order: 2
-isCampsite: true
+category: 'campsite'
 keywords: '密式雨棚, 雨棚露營, 小型包區, 苗栗露營, 泰安露營, 密式旅行, 8人露營, 2帳包區, 1600-2400元, 雨天露營, 避雨露營, 有棚露營, 小團體露營, 經濟實惠'
 mainImage: '/images/campsite_3_main.webp'
 images:

--- a/astro-site/src/content/rooms/log_cabin_1.md
+++ b/astro-site/src/content/rooms/log_cabin_1.md
@@ -10,7 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 5
 numberOfPeople: 4
 order: 9
-isCampsite: false
+category: 'cabin'
 keywords: '觀山之屋, 小木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 山景木屋, 5間木屋, 平價住宿, 觀山住宿, 自然風住宿, 郊外休閒'
 mainImage: '/images/log_cabin_1/log_cabin_1_10.webp'
 images:

--- a/astro-site/src/content/rooms/log_cabin_2.md
+++ b/astro-site/src/content/rooms/log_cabin_2.md
@@ -10,7 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 1
 numberOfPeople: 4
 order: 6
-isCampsite: false
+category: 'cabin'
 keywords: '依山之屋, 靜木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 依山住宿, 寧靜住宿, 小木屋住宿, 郊外休閒, 山景住宿, 自然住宿'
 mainImage: '/images/log_cabin_2_main.webp'
 images:

--- a/astro-site/src/content/rooms/log_cabin_3.md
+++ b/astro-site/src/content/rooms/log_cabin_3.md
@@ -10,7 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 1
 numberOfPeople: 4
 order: 7
-isCampsite: false
+category: 'cabin'
 keywords: '依山之屋, 默木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 依山住宿, 安靜住宿, 小木屋住宿, 郊外休閒, 山景住宿, 禪意住宿'
 mainImage: '/images/log_cabin_3_main.webp'
 images:

--- a/astro-site/src/content/rooms/log_cabin_4.md
+++ b/astro-site/src/content/rooms/log_cabin_4.md
@@ -10,7 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 1
 numberOfPeople: 4
 order: 8
-isCampsite: false
+category: 'cabin'
 keywords: '依山之屋, 沉木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 依山住宿, 涼亭木屋, 小木屋住宿, 郊外休閒, 山景住宿, 有涼亭住宿'
 mainImage: '/images/log_cabin_4_main.webp'
 images:

--- a/astro-site/src/content/rooms/suite_1.md
+++ b/astro-site/src/content/rooms/suite_1.md
@@ -10,7 +10,7 @@ weekdayPrice: 2400
 numberOfRooms: 1
 numberOfPeople: 4
 order: 3
-isCampsite: false
+category: 'suite'
 keywords: '密式之眼, 近雲樓, 四人套房, 苗栗套房, 泰安套房, 密式旅行, 4人住宿, 2400-4600元, 高級套房, 山景套房, 獨立衛浴, 假日含早餐, 有電視冷氣, 精緻住宿'
 mainImage: '/images/suite_1/suite_1_4.webp?v=20260702'
 images:

--- a/astro-site/src/content/rooms/suite_2.md
+++ b/astro-site/src/content/rooms/suite_2.md
@@ -10,7 +10,7 @@ weekdayPrice: 2400
 numberOfRooms: 1
 numberOfPeople: 4
 order: 4
-isCampsite: false
+category: 'suite'
 keywords: '密式之頂, 閲陽樓, 四人套房, 苗栗套房, 泰安套房, 密式旅行, 4人住宿, 2400-4600元, 高級套房, 頂級套房, 獨立衛浴, 假日含早餐, 有電視冷氣, 精品住宿'
 mainImage: '/images/suite_2/suite_2_6.webp?v=20260702'
 images:

--- a/astro-site/src/content/rooms/suite_3.md
+++ b/astro-site/src/content/rooms/suite_3.md
@@ -10,7 +10,7 @@ weekdayPrice: 1600
 numberOfRooms: 2
 numberOfPeople: 2
 order: 5
-isCampsite: false
+category: 'suite'
 keywords: '映月之屋, 雙人套房, 苗栗套房, 泰安套房, 密式旅行, 2人住宿, 1600-2800元, 情侶套房, 小型套房, 獨立衛浴, 假日含早餐, 有電視冷氣, 浪漫住宿, 蜜月住宿'
 mainImage: '/images/suite_3/new_01.webp'
 images:

--- a/astro-site/src/pages/rooms/index.astro
+++ b/astro-site/src/pages/rooms/index.astro
@@ -67,7 +67,7 @@ const itemListSchema = {
                   </p>
                 )}
                 <div class="price-row">
-                  <span>{room.data.isCampsite ? '🏕️ 區域' : '🏠 房數'}：{room.data.numberOfRooms}</span>
+                  <span>{room.data.category === 'campsite' ? '🏕️ 區域' : '🏠 房數'}：{room.data.numberOfRooms}</span>
                   <span>👥 人數：{room.data.numberOfPeople}</span>
                 </div>
               </div>

--- a/astro-site/tests/room-content-model.test.ts
+++ b/astro-site/tests/room-content-model.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const projectDir = join(__dirname, '..');
+const roomsDir = join(projectDir, 'src', 'content', 'rooms');
+
+function readRoom(filename: string) {
+  return readFileSync(join(roomsDir, filename), 'utf-8');
+}
+
+function roomCategory(filename: string) {
+  return readRoom(filename).match(/^category:\s*['\"]?(campsite|cabin|suite)['\"]?$/m)?.[1];
+}
+
+describe('房型內容模型', () => {
+  it('Content Collection 應使用明確三分類，不再使用 isCampsite 布林值', () => {
+    const config = readFileSync(join(projectDir, 'src', 'content.config.ts'), 'utf-8');
+
+    expect(config).toContain("category: z.enum(['campsite', 'cabin', 'suite'])");
+    expect(config).not.toContain('isCampsite');
+  });
+
+  it('每一個房型都必須有且只有合法 category', () => {
+    const roomFiles = readdirSync(roomsDir).filter((filename) => filename.endsWith('.md'));
+
+    expect(roomFiles).toHaveLength(10);
+    roomFiles.forEach((filename) => {
+      const source = readRoom(filename);
+      const categoryMatches = source.match(/^category:/gm) ?? [];
+      expect(categoryMatches, filename).toHaveLength(1);
+      expect(['campsite', 'cabin', 'suite'], filename).toContain(roomCategory(filename));
+      expect(source, filename).not.toContain('isCampsite:');
+    });
+  });
+
+  it('既有十個房型應依實際住宿型態分類', () => {
+    const expectedCategories: Record<string, 'campsite' | 'cabin' | 'suite'> = {
+      'campsite_1.md': 'campsite',
+      'campsite_2.md': 'campsite',
+      'campsite_3.md': 'campsite',
+      'log_cabin_1.md': 'cabin',
+      'log_cabin_2.md': 'cabin',
+      'log_cabin_3.md': 'cabin',
+      'log_cabin_4.md': 'cabin',
+      'suite_1.md': 'suite',
+      'suite_2.md': 'suite',
+      'suite_3.md': 'suite',
+    };
+
+    Object.entries(expectedCategories).forEach(([filename, category]) => {
+      expect(roomCategory(filename), filename).toBe(category);
+    });
+  });
+
+  it('房型列表應以 category 判斷營位與住宿單位顯示', () => {
+    const roomsPage = readFileSync(join(projectDir, 'src', 'pages', 'rooms', 'index.astro'), 'utf-8');
+
+    expect(roomsPage).toContain("room.data.category === 'campsite'");
+    expect(roomsPage).not.toContain('room.data.isCampsite');
+  });
+});


### PR DESCRIPTION
## 變更範圍

這是房型內容架構優化的第一階段，先建立後續房型列表、推薦、Schema 與首頁選房功能所需的資料地基。

- 將原本過粗的 `isCampsite: true/false` 改為明確三分類：
  - `campsite`：露營營位
  - `cabin`：露營木屋
  - `suite`：套房
- 10 個既有房型逐一標記正確分類
- 房型列表改用 `category === 'campsite'` 判斷「區域 / 房數」顯示
- 新增 `room-content-model.test.ts`，保護三分類完整性並防止 `isCampsite` 回流

## 明確不變

- 不修改任何價格
- 不修改任何房型描述或營運文案
- 不修改早餐、寵物、入住、退款、停車或其他規則
- 不修改任何圖片 URL
- 不修改字型或字型載入方式
- 不修改房型詳細頁輪播，避免與現有 PR #44 衝突

## Diff 對抗檢查

目前除新增測試外：

- `content.config.ts`：1 行替換
- 10 個房型 Markdown：每個都只有 1 行替換
- `rooms/index.astro`：1 行替換

也就是說，營運內容沒有被重寫。

## 後續

此 PR 穩定後，下一階段才會利用 `category` 做：

1. 房型列表分組 / 篩選
2. 真正同類型優先的「其他住宿選擇」
3. 房型頁決策資訊重排
4. 首頁「露營 / 木屋 / 套房」選房入口
