### PR TITLE
更新專案指引並保護營運內容與字型

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+Repository guidance for coding agents working on the 密式旅行 website.
+
+## Scope
+
+- Primary app: `astro-site/`
+- Framework: Astro 7, TypeScript, static output on Vercel
+- Validation: `npm run verify` and `npm run test:e2e` from `astro-site/`
+- Production verification: `npm run smoke:production`
+
+## Hard Guardrails
+
+- Do not change room prices, booking/payment flow, refund rules, pet rules, visitor rules, meal policy, check-in/out wording, contact details, or bank-transfer details unless the user explicitly requests that content change.
+- Do not regenerate, replace, subset, expand, or otherwise modify `astro-site/public/fonts/setofont.woff2` unless the user explicitly requests a font change.
+- If new Traditional Chinese text exposes missing glyphs, report or test the coverage issue instead of silently replacing the font.
+- Keep technical/performance work separate from visible content changes whenever practical.
+- Do not opportunistically rewrite approved public wording while doing refactors.
+
+## Change Discipline
+
+- Prefer small branches and narrowly scoped PRs.
+- State explicitly in PR descriptions whether visible content, prices, business rules, images, or fonts changed.
+- Preserve existing route integrity, accessibility behavior, security headers, sitemap/canonical behavior, and production smoke coverage.
+- Add or update regression tests when changing content models, shared booking logic, routes, interactive components, or performance-sensitive loading behavior.
+
+## Content Architecture
+
+- `astro-site/src/content/rooms/`: accommodation data and room-specific copy
+- `astro-site/src/content/infos/`: booking, rules, maps, menus, contact and other guest information
+- `astro-site/src/content/announcements/`: announcements/feed content
+- `astro-site/src/content.config.ts`: content schemas; update schema and all affected entries together
+
+Before adding another SEO, performance, accessibility, or deployment mechanism, inspect the existing implementation and tests so the project does not accumulate duplicate layers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,21 @@ npm run build
 
 # Preview production build
 npm run preview
+
+# Run audit, Astro diagnostics, TypeScript and Vitest
+npm run verify
+
+# Run Chromium interaction tests
+npm run test:e2e
+
+# Verify the public production site
+npm run smoke:production
 ```
 
 ### Deployment
 The site deploys to Vercel automatically when pushing to the main branch. Configuration is in `vercel.json`. The custom domain is `www.misstravel.me`.
+
+GitHub CI runs the full verification suite on pull requests and pushes to `main`. Vercel is responsible for the deployable Astro build, while the production smoke workflow verifies the public site after deployment.
 
 ## Architecture Overview
 
@@ -58,20 +69,25 @@ The site uses Astro content collections for structured content:
 - **announcements/**: Site announcements and updates
 
 ### Key Technologies
-- **Astro 5**: Static site generator with partial hydration
-- **Tailwind CSS 4**: Utility-first CSS framework
-- **Sharp**: Image optimization
+- **Astro 7**: Static site generator
+- **Tailwind CSS 4**: CSS build dependency
+- **Sharp**: Image metadata/processing support
 - **TypeScript**: Type-safe development
 - **Vercel**: Hosting and deployment
+- **Vitest + Playwright**: Static and browser-level regression testing
 
-### Styling
-- Tailwind CSS for utility-based styling
-- Global styles in `src/styles/`
-- Component-scoped styles using Astro's `<style>` tags
+## Protected Content and Files
+
+1. **Do not rewrite operational/business content unless the user explicitly asks for that content change.** This includes room prices, booking/payment flow, refund policy, pet rules, visitor rules, meal policy, check-in/out wording, contact information and bank-transfer details.
+2. **Do not regenerate, replace, subset, expand, or otherwise modify `astro-site/public/fonts/setofont.woff2` unless the user explicitly asks for a font change.** Technical refactors must leave the font file untouched.
+3. When adding or changing visible Traditional Chinese text, remember that the current font is a subset. Treat font glyph coverage as a validation concern; do not silently solve missing glyphs by replacing the font.
+4. Keep technical/performance changes isolated from content changes whenever practical. PR descriptions should explicitly state whether visible content, prices, rules, images, or fonts changed.
+5. Prefer adding regression tests for fixes that protect booking accuracy, route integrity, accessibility, production behavior, or content-model assumptions.
 
 ## Important Considerations
 
 1. **Language**: Site content is primarily in Traditional Chinese (zh-TW)
-2. **Images**: Static images in `public/images/` - optimized with Sharp
-3. **SEO**: Sitemap and RSS feed generation via Astro integrations
-4. **Performance**: Static site with optimized assets and Vercel edge caching
+2. **Images**: Static images are primarily under `public/images/`
+3. **SEO**: Sitemap, structured data, RSS/JSON feeds and canonical metadata are already implemented; do not add SEO markup without checking existing output first
+4. **Performance**: The site is statically generated and already has regression coverage for major technical hardening work
+5. **Deployment safety**: Preserve the existing GitHub CI and production smoke responsibilities when changing build or deployment configuration


### PR DESCRIPTION
## 範圍

這個 PR 只更新 repository-level 開發指引，不修改網站輸出：

- 更新 `CLAUDE.md`
  - Astro 5 → Astro 7
  - 補上 `verify`、Playwright、production smoke 等目前實際流程
  - 明確記錄 GitHub CI / Vercel 的責任分工
- 新增 `AGENTS.md`
  - 提供 Codex 類 coding agents 同等的 repo 級規則
  - 明確保護價格、訂房、退款、寵物、訪客、餐飲、聯絡與匯款資訊
  - 明確禁止未經使用者要求修改 `astro-site/public/fonts/setofont.woff2`
  - 要求技術改動與營運內容改動盡量分離，並以測試保護關鍵行為

## 明確不變

- 不修改任何網站頁面
- 不修改任何字型檔
- 不修改價格、規則、訂房流程或聯絡資訊
- 不修改圖片、CSS、JavaScript、Astro 頁面或部署設定

## 原因

目前 `CLAUDE.md` 的 Astro 版本已落後於實際 package，而且只有 Claude 指引，沒有 Codex 類工具可讀的同級 repo 規則。補上開發護欄可降低未來技術優化時誤動營運內容或字型資產的風險。