### PR TITLE
讓相關住宿優先推薦同類房型

### DIFF
--- a/astro-site/src/content.config.ts
+++ b/astro-site/src/content.config.ts
@@ -29,6 +29,7 @@ const rooms = defineCollection({
     numberOfRooms: z.number(),
     numberOfPeople: z.number(),
     order: z.number(),
+    category: z.enum(['campsite', 'cabin', 'suite']),
     isCampsite: z.boolean().default(false),
     mainImage: z.string(),
     images: z.array(z.string()).default([]),

--- a/astro-site/src/content/rooms/campsite_1.md
+++ b/astro-site/src/content/rooms/campsite_1.md
@@ -25,6 +25,7 @@ priceOptions:
 numberOfRooms: 1
 numberOfPeople: 16
 order: 0
+category: 'campsite'
 isCampsite: true
 keywords: '櫻花之盡, 木棧板露營, 包區露營, 苗栗露營, 泰安露營, 密式旅行, 16人露營, 3帳包區, 4帳包區, 依帳數計價, 2400-4800元, 木平台露營, 家族露營, 團體露營, 櫻花露營區'
 mainImage: '/images/campsite_1_main.webp'

--- a/astro-site/src/content/rooms/campsite_2.md
+++ b/astro-site/src/content/rooms/campsite_2.md
@@ -25,6 +25,7 @@ priceOptions:
 numberOfRooms: 1
 numberOfPeople: 16
 order: 1
+category: 'campsite'
 isCampsite: true
 keywords: '沒日之嶺, 草地露營, 包區露營, 苗栗露營, 泰安露營, 密式旅行, 16人露營, 3帳包區, 4帳包區, 依帳數計價, 2400-4800元, 草地營位, 家族露營, 團體露營, 山景露營'
 mainImage: '/images/campsite_2_main.webp'

--- a/astro-site/src/content/rooms/campsite_3.md
+++ b/astro-site/src/content/rooms/campsite_3.md
@@ -10,6 +10,7 @@ weekdayPrice: 1600
 numberOfRooms: 1
 numberOfPeople: 8
 order: 2
+category: 'campsite'
 isCampsite: true
 keywords: '密式雨棚, 雨棚露營, 小型包區, 苗栗露營, 泰安露營, 密式旅行, 8人露營, 2帳包區, 1600-2400元, 雨天露營, 避雨露營, 有棚露營, 小團體露營, 經濟實惠'
 mainImage: '/images/campsite_3_main.webp'

--- a/astro-site/src/content/rooms/log_cabin_1.md
+++ b/astro-site/src/content/rooms/log_cabin_1.md
@@ -10,6 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 5
 numberOfPeople: 4
 order: 9
+category: 'cabin'
 isCampsite: false
 keywords: '觀山之屋, 小木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 山景木屋, 5間木屋, 平價住宿, 觀山住宿, 自然風住宿, 郊外休閒'
 mainImage: '/images/log_cabin_1/log_cabin_1_10.webp'

--- a/astro-site/src/content/rooms/log_cabin_2.md
+++ b/astro-site/src/content/rooms/log_cabin_2.md
@@ -10,6 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 1
 numberOfPeople: 4
 order: 6
+category: 'cabin'
 isCampsite: false
 keywords: '依山之屋, 靜木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 依山住宿, 寧靜住宿, 小木屋住宿, 郊外休閒, 山景住宿, 自然住宿'
 mainImage: '/images/log_cabin_2_main.webp'

--- a/astro-site/src/content/rooms/log_cabin_3.md
+++ b/astro-site/src/content/rooms/log_cabin_3.md
@@ -10,6 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 1
 numberOfPeople: 4
 order: 7
+category: 'cabin'
 isCampsite: false
 keywords: '依山之屋, 默木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 依山住宿, 安靜住宿, 小木屋住宿, 郊外休閒, 山景住宿, 禪意住宿'
 mainImage: '/images/log_cabin_3_main.webp'

--- a/astro-site/src/content/rooms/log_cabin_4.md
+++ b/astro-site/src/content/rooms/log_cabin_4.md
@@ -10,6 +10,7 @@ weekdayPrice: 1200
 numberOfRooms: 1
 numberOfPeople: 4
 order: 8
+category: 'cabin'
 isCampsite: false
 keywords: '依山之屋, 沉木屋, 露營木屋, 苗栗木屋, 泰安木屋, 密式旅行, 4人木屋, 1200-2000元, 依山住宿, 涼亭木屋, 小木屋住宿, 郊外休閒, 山景住宿, 有涼亭住宿'
 mainImage: '/images/log_cabin_4_main.webp'

--- a/astro-site/src/content/rooms/suite_1.md
+++ b/astro-site/src/content/rooms/suite_1.md
@@ -10,6 +10,7 @@ weekdayPrice: 2400
 numberOfRooms: 1
 numberOfPeople: 4
 order: 3
+category: 'suite'
 isCampsite: false
 keywords: '密式之眼, 近雲樓, 四人套房, 苗栗套房, 泰安套房, 密式旅行, 4人住宿, 2400-4600元, 高級套房, 山景套房, 獨立衛浴, 假日含早餐, 有電視冷氣, 精緻住宿'
 mainImage: '/images/suite_1/suite_1_4.webp?v=20260702'

--- a/astro-site/src/content/rooms/suite_2.md
+++ b/astro-site/src/content/rooms/suite_2.md
@@ -10,6 +10,7 @@ weekdayPrice: 2400
 numberOfRooms: 1
 numberOfPeople: 4
 order: 4
+category: 'suite'
 isCampsite: false
 keywords: '密式之頂, 閲陽樓, 四人套房, 苗栗套房, 泰安套房, 密式旅行, 4人住宿, 2400-4600元, 高級套房, 頂級套房, 獨立衛浴, 假日含早餐, 有電視冷氣, 精品住宿'
 mainImage: '/images/suite_2/suite_2_6.webp?v=20260702'

--- a/astro-site/src/content/rooms/suite_3.md
+++ b/astro-site/src/content/rooms/suite_3.md
@@ -10,6 +10,7 @@ weekdayPrice: 1600
 numberOfRooms: 2
 numberOfPeople: 2
 order: 5
+category: 'suite'
 isCampsite: false
 keywords: '映月之屋, 雙人套房, 苗栗套房, 泰安套房, 密式旅行, 2人住宿, 1600-2800元, 情侶套房, 小型套房, 獨立衛浴, 假日含早餐, 有電視冷氣, 浪漫住宿, 蜜月住宿'
 mainImage: '/images/suite_3/new_01.webp'

--- a/astro-site/src/lib/room-category.ts
+++ b/astro-site/src/lib/room-category.ts
@@ -1,0 +1,7 @@
+export const roomCategoryLabels = {
+  campsite: '露營營位',
+  cabin: '露營木屋',
+  suite: '套房',
+} as const;
+
+export type RoomCategory = keyof typeof roomCategoryLabels;

--- a/astro-site/src/lib/room-category.ts
+++ b/astro-site/src/lib/room-category.ts
@@ -1,7 +1,0 @@
-export const roomCategoryLabels = {
-  campsite: '露營營位',
-  cabin: '露營木屋',
-  suite: '套房',
-} as const;
-
-export type RoomCategory = keyof typeof roomCategoryLabels;

--- a/astro-site/src/pages/rooms/[...slug].astro
+++ b/astro-site/src/pages/rooms/[...slug].astro
@@ -19,11 +19,25 @@ const carouselImages = room.data.images.includes(room.data.mainImage)
   ? room.data.images
   : [room.data.mainImage, ...room.data.images];
 
-// Get related rooms (same type or different)
+// Prefer the same accommodation category, then the closest capacity and weekday price.
 const allRooms = await getCollection('rooms');
 const relatedRooms = allRooms
-  .filter((r) => r.id !== room.id)
-  .sort((a, b) => a.data.order - b.data.order)
+  .filter((candidate) => candidate.id !== room.id)
+  .sort((a, b) => {
+    const categoryDifference = Number(a.data.category !== room.data.category)
+      - Number(b.data.category !== room.data.category);
+    if (categoryDifference !== 0) return categoryDifference;
+
+    const capacityDifference = Math.abs(a.data.numberOfPeople - room.data.numberOfPeople)
+      - Math.abs(b.data.numberOfPeople - room.data.numberOfPeople);
+    if (capacityDifference !== 0) return capacityDifference;
+
+    const priceDifference = Math.abs(a.data.weekdayPrice - room.data.weekdayPrice)
+      - Math.abs(b.data.weekdayPrice - room.data.weekdayPrice);
+    if (priceDifference !== 0) return priceDifference;
+
+    return a.data.order - b.data.order;
+  })
   .slice(0, 3);
 
 const roomUrl = `${siteConfig.url}/rooms/${room.id.replace('.md', '')}/`;

--- a/astro-site/tests/related-room-ranking.test.ts
+++ b/astro-site/tests/related-room-ranking.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'cheerio';
+
+const distDir = join(__dirname, '..', 'dist');
+
+function relatedRoomHrefs(slug: string) {
+  const html = readFileSync(join(distDir, 'rooms', slug, 'index.html'), 'utf-8');
+  const $ = load(html);
+  return $('.related-card')
+    .map((_, element) => $(element).attr('href'))
+    .get();
+}
+
+describe('相關住宿排序', () => {
+  it('露營木屋應優先推薦其他露營木屋', () => {
+    expect(relatedRoomHrefs('log_cabin_4')).toEqual([
+      '/rooms/log_cabin_2/',
+      '/rooms/log_cabin_3/',
+      '/rooms/log_cabin_1/',
+    ]);
+  });
+
+  it('雙人套房應先推薦其他套房，再補最接近的其他住宿', () => {
+    expect(relatedRoomHrefs('suite_3')).toEqual([
+      '/rooms/suite_1/',
+      '/rooms/suite_2/',
+      '/rooms/log_cabin_2/',
+    ]);
+  });
+
+  it('雨棚營位應先推薦其他營位，再補最接近的其他住宿', () => {
+    expect(relatedRoomHrefs('campsite_3')).toEqual([
+      '/rooms/campsite_1/',
+      '/rooms/campsite_2/',
+      '/rooms/log_cabin_2/',
+    ]);
+  });
+});

--- a/astro-site/tests/room-category-integrity.test.ts
+++ b/astro-site/tests/room-category-integrity.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const projectDir = join(__dirname, '..');
+const contentDir = join(projectDir, 'src', 'content', 'rooms');
+
+const expectedCategories = {
+  campsite_1: 'campsite',
+  campsite_2: 'campsite',
+  campsite_3: 'campsite',
+  log_cabin_1: 'cabin',
+  log_cabin_2: 'cabin',
+  log_cabin_3: 'cabin',
+  log_cabin_4: 'cabin',
+  suite_1: 'suite',
+  suite_2: 'suite',
+  suite_3: 'suite',
+} as const;
+
+describe('房型分類資料完整性', () => {
+  it('所有公開房型都必須有明確三分類', () => {
+    const roomSlugs = readdirSync(contentDir)
+      .filter((file) => file.endsWith('.md') && !file.startsWith('_'))
+      .map((file) => file.replace(/\.md$/, ''))
+      .sort();
+
+    expect(roomSlugs).toEqual(Object.keys(expectedCategories).sort());
+
+    for (const [slug, category] of Object.entries(expectedCategories)) {
+      const source = readFileSync(join(contentDir, `${slug}.md`), 'utf-8');
+      expect(source.match(/^category:/gm), `${slug}: category 應只出現一次`).toHaveLength(1);
+      expect(source, `${slug}: category 應為 ${category}`).toContain(`category: '${category}'`);
+    }
+  });
+
+  it('三分類導入期間應維持既有 isCampsite 相容性', () => {
+    for (const [slug, category] of Object.entries(expectedCategories)) {
+      const source = readFileSync(join(contentDir, `${slug}.md`), 'utf-8');
+      const expectedLegacyValue = category === 'campsite';
+      expect(source, `${slug}: isCampsite 應與 category 一致`).toContain(`isCampsite: ${expectedLegacyValue}`);
+    }
+  });
+
+  it('Astro content schema 應限制 category 僅能使用三種合法值', () => {
+    const schema = readFileSync(join(projectDir, 'src', 'content.config.ts'), 'utf-8');
+    expect(schema).toContain("category: z.enum(['campsite', 'cabin', 'suite'])");
+  });
+});


### PR DESCRIPTION
## 範圍

此 PR 依賴的 #46 房型三分類已合併到 `main`，本 PR 只調整「其他住宿選擇」排序：

1. 同 `category` 優先
2. 容納人數差距較小者優先
3. 平日價格差距較小者優先
4. 最後以既有 `order` 保持穩定排序

## 代表效果

- 露營木屋頁會優先推薦其他露營木屋
- 套房頁會先推薦其他套房，不足三個時再補最接近的其他住宿
- 營位頁會先推薦其他營位，不足三個時再補最接近的其他住宿

## 驗證

- 新增 build-output 回歸測試，直接檢查代表頁面產生的相關住宿連結排序
- 原 stacked branch CI 已全數通過
- retarget `main` 後 GitHub mergeability 已確認為 true
- 已抽查 GitHub 臨時 merge commit：#47 的 `AGENTS.md`、#46 的 `category` schema 與本 PR 的排序邏輯可同時保留

## 明確不變

- 不修改價格、規則、訂房流程或任何房型文案
- 不修改圖片或字型
- 不修改卡片視覺樣式
- 不包含 PR #44 的輪播圖片延遲載入

註：因 #46 先前採 squash merge，GitHub 在 PR 歷史視圖仍會列出原 stacked commits；實際 merge tree 已確認不會回退 `main` 已合併內容。