### PR TITLE
依住宿類型整理房型列表

### DIFF
--- a/astro-site/src/pages/rooms/index.astro
+++ b/astro-site/src/pages/rooms/index.astro
@@ -6,6 +6,11 @@ import { siteConfig } from '../../lib/config';
 
 const rooms = await getCollection('rooms');
 const sortedRooms = rooms.sort((a, b) => a.data.order - b.data.order);
+const categories = [
+  { id: 'campsite', label: '露營營位', icon: '🏕️' },
+  { id: 'cabin', label: '露營木屋', icon: '🏡' },
+  { id: 'suite', label: '套房', icon: '🛏️' },
+] as const;
 
 const itemListSchema = {
   '@context': 'https://schema.org',
@@ -22,8 +27,8 @@ const itemListSchema = {
 
 <BaseLayout
   title="房型展示"
-  description="密式旅行提供多樣化住宿選擇：露營車位享受大自然、溫馨小木屋適合家庭、舒適套房給您飯店般體驗。"
-  keywords="密式旅行房型,露營車位,小木屋住宿,套房住宿,苗栗住宿價格"
+  description="密式旅行提供多樣化住宿選擇：露營營位享受大自然、溫馨露營木屋適合家庭、舒適套房提供完整住宿空間。"
+  keywords="密式旅行房型,露營營位,露營木屋,套房住宿,苗栗住宿價格"
   extraSchemas={[itemListSchema]}
 >
   <main id="main" class="alt">
@@ -32,49 +37,80 @@ const itemListSchema = {
       <header class="major">
         <h1>房型展示</h1>
       </header>
-      <div class="rooms-grid">
-        {sortedRooms.map((room) => {
-          const alternativeOption = room.data.priceOptions?.find((option) => !option.isStandard);
 
+      <nav class="category-nav" aria-label="住宿類型快速導覽">
+        {categories.map((category) => {
+          const count = sortedRooms.filter((room) => room.data.category === category.id).length;
           return (
-            <a href={`/rooms/${room.id.replace('.md', '')}/`} class="room-card">
-              <h2>{room.data.title}</h2>
-              <div class="room-image">
-                <img
-                  src={room.data.mainImage}
-                  alt={`${room.data.shortTitle}住宿外觀`}
-                  loading="lazy"
-                  decoding="async"
-                  width="600"
-                  height="400"
-                />
-              </div>
-              <div class="room-prices">
-                {room.data.priceOptions && (
-                  <p class="pricing-basis">四帳標準方案｜實際依帳數計價</p>
-                )}
-                <div class="price-row">
-                  <span>👑 訂價：{room.data.standardPrice}</span>
-                  <span>🥇 連假：{room.data.standardPrice}</span>
-                </div>
-                <div class="price-row">
-                  <span>🥈 假日：{room.data.holidayPrice}</span>
-                  <span>🥉 平日：{room.data.weekdayPrice}</span>
-                </div>
-                {alternativeOption && (
-                  <p class="alternative-price">
-                    三帳方案：平日 {alternativeOption.weekdayPrice}／假日 {alternativeOption.holidayPrice}／連假 {alternativeOption.standardPrice} 元
-                  </p>
-                )}
-                <div class="price-row">
-                  <span>{room.data.isCampsite ? '🏕️ 區域' : '🏠 房數'}：{room.data.numberOfRooms}</span>
-                  <span>👥 人數：{room.data.numberOfPeople}</span>
-                </div>
-              </div>
+            <a href={`#${category.id}`} class="category-link">
+              <span class="category-icon" aria-hidden="true">{category.icon}</span>
+              <span>{category.label}</span>
+              <small>{count} 種選擇</small>
             </a>
           );
         })}
-      </div>
+      </nav>
+
+      {categories.map((category) => {
+        const categoryRooms = sortedRooms.filter((room) => room.data.category === category.id);
+
+        return (
+          <section id={category.id} class="room-category" aria-labelledby={`${category.id}-title`}>
+            <div class="category-heading">
+              <span class="category-heading-icon" aria-hidden="true">{category.icon}</span>
+              <div>
+                <p>住宿類型</p>
+                <h2 id={`${category.id}-title`}>{category.label}</h2>
+              </div>
+              <span class="category-count">{categoryRooms.length} 種選擇</span>
+            </div>
+
+            <div class="rooms-grid">
+              {categoryRooms.map((room) => {
+                const alternativeOption = room.data.priceOptions?.find((option) => !option.isStandard);
+
+                return (
+                  <a href={`/rooms/${room.id.replace('.md', '')}/`} class="room-card">
+                    <h3>{room.data.title}</h3>
+                    <div class="room-image">
+                      <img
+                        src={room.data.mainImage}
+                        alt={`${room.data.shortTitle}住宿外觀`}
+                        loading="lazy"
+                        decoding="async"
+                        width="600"
+                        height="400"
+                      />
+                    </div>
+                    <div class="room-prices">
+                      {room.data.priceOptions && (
+                        <p class="pricing-basis">四帳標準方案｜實際依帳數計價</p>
+                      )}
+                      <div class="price-row">
+                        <span>👑 訂價：{room.data.standardPrice}</span>
+                        <span>🥇 連假：{room.data.standardPrice}</span>
+                      </div>
+                      <div class="price-row">
+                        <span>🥈 假日：{room.data.holidayPrice}</span>
+                        <span>🥉 平日：{room.data.weekdayPrice}</span>
+                      </div>
+                      {alternativeOption && (
+                        <p class="alternative-price">
+                          三帳方案：平日 {alternativeOption.weekdayPrice}／假日 {alternativeOption.holidayPrice}／連假 {alternativeOption.standardPrice} 元
+                        </p>
+                      )}
+                      <div class="price-row">
+                        <span>{room.data.category === 'campsite' ? '🏕️ 區域' : '🏠 房數'}：{room.data.numberOfRooms}</span>
+                        <span>👥 人數：{room.data.numberOfPeople}</span>
+                      </div>
+                    </div>
+                  </a>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
     </div>
   </main>
 </BaseLayout>
@@ -92,7 +128,7 @@ const itemListSchema = {
   }
 
   header.major {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 
   header.major h1 {
@@ -101,6 +137,85 @@ const itemListSchema = {
     padding-bottom: 0.5rem;
     border-bottom: solid 2px #fff;
     display: inline-block;
+  }
+
+  .category-nav {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem;
+    margin-bottom: 3rem;
+  }
+
+  .category-link {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    column-gap: 0.75rem;
+    align-items: center;
+    padding: 0.9rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    color: #fff;
+    transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  }
+
+  .category-link:hover,
+  .category-link:focus-visible {
+    background: rgba(155, 241, 255, 0.12);
+    border-color: #9bf1ff;
+    transform: translateY(-2px);
+  }
+
+  .category-icon {
+    grid-row: 1 / 3;
+    font-size: 1.5rem;
+  }
+
+  .category-link small {
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.75rem;
+  }
+
+  .room-category {
+    scroll-margin-top: 6rem;
+    margin-bottom: 3.5rem;
+  }
+
+  .room-category:last-child {
+    margin-bottom: 0;
+  }
+
+  .category-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+  }
+
+  .category-heading-icon {
+    font-size: 2rem;
+  }
+
+  .category-heading p {
+    margin: 0 0 0.15rem;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+  }
+
+  .category-heading h2 {
+    margin: 0;
+    font-size: 1.6rem;
+    letter-spacing: 0.08em;
+  }
+
+  .category-count {
+    margin-left: auto;
+    color: #9bf1ff;
+    font-size: 0.85rem;
   }
 
   .rooms-grid {
@@ -122,7 +237,7 @@ const itemListSchema = {
     transform: translateY(-5px);
   }
 
-  .room-card h2 {
+  .room-card h3 {
     font-size: 1.1rem;
     margin: 0;
     padding: 0.75rem;
@@ -201,6 +316,23 @@ const itemListSchema = {
 
     header.major h1 {
       font-size: 2rem;
+    }
+
+    .category-nav {
+      grid-template-columns: 1fr;
+      margin-bottom: 2rem;
+    }
+
+    .room-category {
+      margin-bottom: 2.5rem;
+    }
+
+    .category-heading {
+      align-items: flex-start;
+    }
+
+    .category-count {
+      font-size: 0.78rem;
     }
 
     .rooms-grid {

--- a/astro-site/src/pages/rooms/index.astro
+++ b/astro-site/src/pages/rooms/index.astro
@@ -71,7 +71,7 @@ const itemListSchema = {
 
                 return (
                   <a href={`/rooms/${room.id.replace('.md', '')}/`} class="room-card">
-                    <h3>{room.data.title}</h3>
+                    <h2>{room.data.title}</h2>
                     <div class="room-image">
                       <img
                         src={room.data.mainImage}
@@ -237,7 +237,7 @@ const itemListSchema = {
     transform: translateY(-5px);
   }
 
-  .room-card h3 {
+  .room-card h2 {
     font-size: 1.1rem;
     margin: 0;
     padding: 0.75rem;

--- a/astro-site/tests/campsite-pricing-integrity.test.ts
+++ b/astro-site/tests/campsite-pricing-integrity.test.ts
@@ -44,7 +44,7 @@ describe('3 至 4 帳包區價格完整性', () => {
     const $ = readPage('rooms/index.html');
 
     for (const title of ['櫻花之盡', '沒日之嶺']) {
-      const card = $('.room-card').filter((_, element) => $(element).find('h2, h3').text().includes(title));
+      const card = $('.room-card').filter((_, element) => $(element).find('h2').text().includes(title));
       const text = card.text().replace(/\s+/g, ' ');
 
       expect(card).toHaveLength(1);
@@ -81,7 +81,7 @@ describe('3 至 4 帳包區價格完整性', () => {
   it('其他住宿卡片不應出現帳數計價提示', () => {
     const $ = readPage('rooms/index.html');
     const normalCards = $('.room-card').filter((_, element) => {
-      const title = $(element).find('h2, h3').text();
+      const title = $(element).find('h2').text();
       return !title.includes('櫻花之盡') && !title.includes('沒日之嶺');
     });
 

--- a/astro-site/tests/campsite-pricing-integrity.test.ts
+++ b/astro-site/tests/campsite-pricing-integrity.test.ts
@@ -44,7 +44,7 @@ describe('3 至 4 帳包區價格完整性', () => {
     const $ = readPage('rooms/index.html');
 
     for (const title of ['櫻花之盡', '沒日之嶺']) {
-      const card = $('.room-card').filter((_, element) => $(element).find('h2').text().includes(title));
+      const card = $('.room-card').filter((_, element) => $(element).find('h2, h3').text().includes(title));
       const text = card.text().replace(/\s+/g, ' ');
 
       expect(card).toHaveLength(1);
@@ -81,7 +81,7 @@ describe('3 至 4 帳包區價格完整性', () => {
   it('其他住宿卡片不應出現帳數計價提示', () => {
     const $ = readPage('rooms/index.html');
     const normalCards = $('.room-card').filter((_, element) => {
-      const title = $(element).find('h2').text();
+      const title = $(element).find('h2, h3').text();
       return !title.includes('櫻花之盡') && !title.includes('沒日之嶺');
     });
 

--- a/astro-site/tests/room-list-category-ux.test.ts
+++ b/astro-site/tests/room-list-category-ux.test.ts
@@ -13,18 +13,19 @@ function readRoomsPage() {
 describe('房型列表三分類導覽', () => {
   it('應提供露營營位、露營木屋與套房三個快速導覽入口', () => {
     const $ = readRoomsPage();
-    const links = $('.category-nav .category-link')
-      .toArray()
-      .map((element) => ({
-        href: $(element).attr('href'),
-        text: $(element).text().replace(/\s+/g, ' ').trim(),
-      }));
+    const links = $('.category-nav .category-link');
+    const expected = [
+      { href: '#campsite', label: '露營營位', count: '3 種選擇' },
+      { href: '#cabin', label: '露營木屋', count: '4 種選擇' },
+      { href: '#suite', label: '套房', count: '3 種選擇' },
+    ];
 
-    expect(links).toEqual([
-      { href: '#campsite', text: '🏕️ 露營營位 3 種選擇' },
-      { href: '#cabin', text: '🏡 露營木屋 4 種選擇' },
-      { href: '#suite', text: '🛏️ 套房 3 種選擇' },
-    ]);
+    expect(links).toHaveLength(3);
+    links.each((index, element) => {
+      expect($(element).attr('href')).toBe(expected[index].href);
+      expect($(element).find('span').not('.category-icon').text().trim()).toBe(expected[index].label);
+      expect($(element).find('small').text().trim()).toBe(expected[index].count);
+    });
   });
 
   it('所有房型應只出現在自己的分類區塊一次', () => {
@@ -42,7 +43,7 @@ describe('房型列表三分類導覽', () => {
       expect(cards, `${category} 房型數量`).toHaveLength(expectation.count);
       cards.each((_, element) => {
         expect($(element).attr('href')).toMatch(new RegExp(`^${expectation.prefix}`));
-        expect($(element).find('h3')).toHaveLength(1);
+        expect($(element).find('h2')).toHaveLength(1);
       });
     }
   });

--- a/astro-site/tests/room-list-category-ux.test.ts
+++ b/astro-site/tests/room-list-category-ux.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'cheerio';
+
+const projectDir = join(__dirname, '..');
+const distDir = join(projectDir, 'dist');
+
+function readRoomsPage() {
+  return load(readFileSync(join(distDir, 'rooms', 'index.html'), 'utf-8'));
+}
+
+describe('房型列表三分類導覽', () => {
+  it('應提供露營營位、露營木屋與套房三個快速導覽入口', () => {
+    const $ = readRoomsPage();
+    const links = $('.category-nav .category-link')
+      .toArray()
+      .map((element) => ({
+        href: $(element).attr('href'),
+        text: $(element).text().replace(/\s+/g, ' ').trim(),
+      }));
+
+    expect(links).toEqual([
+      { href: '#campsite', text: '🏕️ 露營營位 3 種選擇' },
+      { href: '#cabin', text: '🏡 露營木屋 4 種選擇' },
+      { href: '#suite', text: '🛏️ 套房 3 種選擇' },
+    ]);
+  });
+
+  it('所有房型應只出現在自己的分類區塊一次', () => {
+    const $ = readRoomsPage();
+    const expected = {
+      campsite: { count: 3, prefix: '/rooms/campsite_' },
+      cabin: { count: 4, prefix: '/rooms/log_cabin_' },
+      suite: { count: 3, prefix: '/rooms/suite_' },
+    } as const;
+
+    expect($('.room-card')).toHaveLength(10);
+
+    for (const [category, expectation] of Object.entries(expected)) {
+      const cards = $(`#${category} .room-card`);
+      expect(cards, `${category} 房型數量`).toHaveLength(expectation.count);
+      cards.each((_, element) => {
+        expect($(element).attr('href')).toMatch(new RegExp(`^${expectation.prefix}`));
+        expect($(element).find('h3')).toHaveLength(1);
+      });
+    }
+  });
+
+  it('房型列表應使用 category 判斷營位，不再依賴舊 isCampsite', () => {
+    const source = readFileSync(join(projectDir, 'src', 'pages', 'rooms', 'index.astro'), 'utf-8');
+    expect(source).toContain("room.data.category === 'campsite'");
+    expect(source).not.toContain('room.data.isCampsite');
+  });
+
+  it('頁面搜尋描述應使用露營營位而不是露營車位', () => {
+    const $ = readRoomsPage();
+    const description = $('meta[name="description"]').attr('content') || '';
+    expect(description).toContain('露營營位');
+    expect(description).not.toContain('露營車位');
+  });
+});


### PR DESCRIPTION
## 範圍

利用已合併的房型 `category` 三分類，讓 `/rooms/` 真正呈現住宿類型層級：

- 頁首新增三個快速導覽入口：露營營位／露營木屋／套房
- 房型卡片依 category 分成三個區塊，不再全部混在同一個 grid
- 每個分類顯示目前選擇數量
- 房型卡片維持既有 `h2` SEO / 標題規範
- 「區域 / 房數」改由 `category === 'campsite'` 判斷，不再依賴舊 `isCampsite`
- SEO description / keywords 將不精確的「露營車位」修正為「露營營位」

## 明確不變

- 不修改任何房價數字或價格標籤
- 不修改房型規則、早餐、寵物、訂房或退款內容
- 不修改圖片或字型
- 不修改房型詳細頁

## 驗證

初版 CI 找到兩個測試相容性問題（既有 h2 規範、inline whitespace），皆已依現有規範修正；最新版 GitHub CI run #159 已完整通過 build、167 個 Vitest 與 Playwright。

Vercel Preview 因 Hobby build-rate-limit 未建立，屬平台配額限制而非程式 build 失敗。