### PR TITLE
補強房型頁決策摘要與空房查詢入口

### DIFF
--- a/astro-site/src/pages/rooms/[...slug].astro
+++ b/astro-site/src/pages/rooms/[...slug].astro
@@ -19,6 +19,18 @@ const carouselImages = room.data.images.includes(room.data.mainImage)
   ? room.data.images
   : [room.data.mainImage, ...room.data.images];
 
+const roomCategoryLabels = {
+  campsite: '露營營位',
+  cabin: '露營木屋',
+  suite: '套房',
+} as const;
+const roomCategoryLabel = roomCategoryLabels[room.data.category];
+const weekdayPrices = [
+  room.data.weekdayPrice,
+  ...(room.data.priceOptions?.map((option) => option.weekdayPrice) ?? []),
+];
+const startingWeekdayPrice = Math.min(...weekdayPrices);
+
 // Prefer the same accommodation category, then the closest capacity and weekday price.
 const allRooms = await getCollection('rooms');
 const relatedRooms = allRooms
@@ -77,10 +89,25 @@ const productSchema = {
         { label: '房型展示', href: '/rooms/' },
         { label: room.data.shortTitle }
       ]} />
-    <header class="major">
-      <h1>{room.data.title}</h1>
-    </header>
-  </div>
+      <header class="major">
+        <h1>{room.data.title}</h1>
+      </header>
+      <div class="room-summary" aria-label="房型摘要">
+        <div class="summary-facts">
+          <span class="summary-category">{roomCategoryLabel}</span>
+          <span>👥 {room.data.numberOfPeople} 人</span>
+          <span>平日 NT${startingWeekdayPrice.toLocaleString('zh-TW')} 起</span>
+        </div>
+        <a
+          href={siteConfig.booking.url}
+          class="availability-cta"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          查詢空房
+        </a>
+      </div>
+    </div>
 
   <div id="main-content" class="room-detail">
     <div class="inner-content">
@@ -212,6 +239,54 @@ const productSchema = {
     display: inline-block;
     padding-bottom: 0.5rem;
     margin-bottom: 0;
+  }
+
+  .room-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 1.25rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .summary-facts {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem 1rem;
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 0.9rem;
+  }
+
+  .summary-category {
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(155, 241, 255, 0.12);
+    color: #9bf1ff;
+    font-weight: 600;
+  }
+
+  .availability-cta {
+    flex: 0 0 auto;
+    display: inline-block;
+    padding: 0.7rem 1.1rem;
+    border: 2px solid #9bf1ff;
+    border-radius: 6px;
+    background: #9bf1ff;
+    color: #242943;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+
+  .availability-cta:hover,
+  .availability-cta:focus-visible {
+    background: transparent;
+    color: #9bf1ff;
   }
 
   #main-content {
@@ -395,7 +470,7 @@ const productSchema = {
     color: rgba(255, 255, 255, 0.9);
   }
 
-  /* Day Definition */
+  /* Day Type Definition */
   .day-definition {
     margin-bottom: 2rem;
   }
@@ -468,6 +543,16 @@ const productSchema = {
 
     .page-header h1 {
       font-size: 1.5rem;
+    }
+
+    .room-summary {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .availability-cta {
+      width: 100%;
+      text-align: center;
     }
 
     .price-grid {

--- a/astro-site/tests/room-detail-decision-ux.test.ts
+++ b/astro-site/tests/room-detail-decision-ux.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'cheerio';
+import { siteConfig } from '../src/lib/config';
+
+const projectDir = join(__dirname, '..');
+const distDir = join(projectDir, 'dist');
+
+function readRoomPage(slug: string) {
+  return load(readFileSync(join(distDir, 'rooms', slug, 'index.html'), 'utf-8'));
+}
+
+describe('房型詳情決策資訊', () => {
+  it.each([
+    ['campsite_1', '露營營位', '16 人', '平日 NT$2,400 起'],
+    ['log_cabin_4', '露營木屋', '4 人', '平日 NT$1,200 起'],
+    ['suite_3', '套房', '2 人', '平日 NT$1,600 起'],
+  ])('%s 應在頁首顯示類型、人數與正確平日起價', (slug, category, people, price) => {
+    const $ = readRoomPage(slug);
+    const summary = $('.room-summary').text().replace(/\s+/g, ' ').trim();
+
+    expect($('.room-summary')).toHaveLength(1);
+    expect(summary).toContain(category);
+    expect(summary).toContain(people);
+    expect(summary).toContain(price);
+  });
+
+  it.each(['campsite_1', 'log_cabin_4', 'suite_3'])('%s 應提供官方空房查詢入口', (slug) => {
+    const $ = readRoomPage(slug);
+    const cta = $('.availability-cta');
+
+    expect(cta).toHaveLength(1);
+    expect(cta.text().trim()).toBe('查詢空房');
+    expect(cta.attr('href')).toBe(siteConfig.booking.url);
+    expect(cta.attr('target')).toBe('_blank');
+    expect(cta.attr('rel')).toContain('noopener');
+    expect(cta.attr('rel')).toContain('noreferrer');
+  });
+
+  it('三至四帳包區摘要應使用 priceOptions 的最低平日價作為起價', () => {
+    const $ = readRoomPage('campsite_1');
+    expect($('.room-summary').text()).toContain('NT$2,400 起');
+    expect($('.room-summary').text()).not.toContain('NT$3,200 起');
+  });
+});


### PR DESCRIPTION
## 範圍

在房型詳情頁標題下方新增一個精簡決策摘要，不重排既有訂房內容：

- 顯示住宿類型：露營營位／露營木屋／套房
- 顯示目前房型人數
- 顯示平日起價
  - 若房型有 `priceOptions`，自動取最低平日價
  - 例如櫻花之盡會顯示 2400 起，而不是標準四帳 3200 起
- 新增「查詢空房」主 CTA，連到既有 `siteConfig.booking.url`
- 手機版 CTA 改為滿寬呈現

## 明確不變

- 不修改任何房價資料
- 不修改訂房、退款、早餐、寵物、訪客或其他規則文字
- 不修改圖片、字型或 RoomCloud URL
- 不修改 #44 已合併的 deferred image / carousel JS
- 原本「訂房流程」「園內規約」按鈕與訂位須知全部保留

## 測試

新增 build-output 回歸測試，驗證代表營位／木屋／套房的類型、人數、起價與官方空房查詢連結。

先以 Draft 執行完整 CI / Vercel 驗證。