### PR TITLE
在首頁加入住宿方式入口

### DIFF
--- a/astro-site/src/components/StayChoices.astro
+++ b/astro-site/src/components/StayChoices.astro
@@ -1,0 +1,277 @@
+---
+import { getCollection } from 'astro:content';
+
+const rooms = (await getCollection('rooms')).sort((a, b) => a.data.order - b.data.order);
+const categories = [
+  {
+    id: 'campsite',
+    title: '露營營位',
+    description: '選擇營位住宿，親近山景與自然。',
+    icon: '🏕️',
+  },
+  {
+    id: 'cabin',
+    title: '露營木屋',
+    description: '入住木屋，在山林景色中放慢步調。',
+    icon: '🏡',
+  },
+  {
+    id: 'suite',
+    title: '套房',
+    description: '想要完整房間空間，也可以選擇套房。',
+    icon: '🛏️',
+  },
+] as const;
+
+const stayChoices = categories.map((category) => {
+  const categoryRooms = rooms.filter((room) => room.data.category === category.id);
+  return {
+    ...category,
+    count: categoryRooms.length,
+    image: categoryRooms[0]?.data.mainImage,
+  };
+});
+
+const highlights = ['泰安山景', '上百款桌遊', '兒童遊戲室', '沙坑'];
+---
+
+<section class="stay-choices" aria-labelledby="stay-choices-title">
+  <div class="stay-inner">
+    <div class="section-heading">
+      <p class="eyebrow">先從想怎麼住開始</p>
+      <h2 id="stay-choices-title">選擇住宿方式</h2>
+      <p class="section-intro">密式旅行提供露營營位、露營木屋與套房三種住宿方式，可以先挑喜歡的類型，再查看各房型與價格。</p>
+    </div>
+
+    <div class="stay-grid">
+      {stayChoices.map((choice) => (
+        <a href={`/rooms/#${choice.id}`} class="stay-card">
+          {choice.image && (
+            <span class="stay-image">
+              <img
+                src={choice.image}
+                alt={`${choice.title}代表住宿實景`}
+                loading="lazy"
+                decoding="async"
+                width="640"
+                height="400"
+              />
+            </span>
+          )}
+          <span class="stay-copy">
+            <span class="stay-title-row">
+              <span class="stay-icon" aria-hidden="true">{choice.icon}</span>
+              <strong>{choice.title}</strong>
+              <small>{choice.count} 種選擇</small>
+            </span>
+            <span class="stay-description">{choice.description}</span>
+            <span class="stay-link">查看這類住宿 →</span>
+          </span>
+        </a>
+      ))}
+    </div>
+
+    <div class="home-highlights" aria-label="園區特色">
+      <span class="highlight-label">來到密式還有</span>
+      {highlights.map((highlight) => <span class="highlight-chip">{highlight}</span>)}
+      <a href="/infos/" class="highlight-more">認識園區 →</a>
+    </div>
+  </div>
+</section>
+
+<style>
+  .stay-choices {
+    background: #242943;
+    padding: 4rem 0 3rem;
+  }
+
+  .stay-inner {
+    max-width: 65em;
+    margin: 0 auto;
+    padding: 0 3em;
+  }
+
+  .section-heading {
+    max-width: 46rem;
+    margin-bottom: 2rem;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.35rem;
+    color: #9bf1ff;
+    font-size: 0.8rem;
+    letter-spacing: 0.14em;
+  }
+
+  .section-heading h2 {
+    margin: 0 0 0.8rem;
+    font-size: 2.15rem;
+    letter-spacing: 0.08em;
+  }
+
+  .section-intro {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.8;
+  }
+
+  .stay-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+  }
+
+  .stay-card {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.05);
+    color: #fff;
+    transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  }
+
+  .stay-card:hover,
+  .stay-card:focus-visible {
+    transform: translateY(-4px);
+    border-color: #9bf1ff;
+    background: rgba(155, 241, 255, 0.08);
+  }
+
+  .stay-image {
+    display: block;
+    aspect-ratio: 16 / 10;
+    overflow: hidden;
+  }
+
+  .stay-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.35s ease;
+  }
+
+  .stay-card:hover .stay-image img {
+    transform: scale(1.035);
+  }
+
+  .stay-copy {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    padding: 1rem 1.1rem 1.15rem;
+  }
+
+  .stay-title-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.55rem;
+    margin-bottom: 0.65rem;
+  }
+
+  .stay-icon {
+    font-size: 1.25rem;
+  }
+
+  .stay-title-row strong {
+    font-size: 1.05rem;
+    letter-spacing: 0.06em;
+  }
+
+  .stay-title-row small {
+    color: rgba(255, 255, 255, 0.58);
+    font-size: 0.72rem;
+  }
+
+  .stay-description {
+    min-height: 3.2em;
+    color: rgba(255, 255, 255, 0.76);
+    font-size: 0.9rem;
+    line-height: 1.65;
+  }
+
+  .stay-link {
+    margin-top: auto;
+    padding-top: 0.9rem;
+    color: #9bf1ff;
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+
+  .home-highlights {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.55rem;
+    margin-top: 1.4rem;
+    padding: 0.9rem 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.16);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.16);
+  }
+
+  .highlight-label {
+    margin-right: 0.2rem;
+    color: rgba(255, 255, 255, 0.68);
+    font-size: 0.82rem;
+  }
+
+  .highlight-chip {
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.88);
+    font-size: 0.8rem;
+  }
+
+  .highlight-more {
+    margin-left: auto;
+    color: #9bf1ff;
+    font-size: 0.82rem;
+  }
+
+  @media (max-width: 980px) {
+    .stay-inner {
+      padding: 0 1.5em;
+    }
+
+    .stay-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .stay-card {
+      display: grid;
+      grid-template-columns: minmax(180px, 34%) 1fr;
+    }
+
+    .stay-image {
+      height: 100%;
+      aspect-ratio: auto;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .stay-choices {
+      padding: 3rem 0 2.5rem;
+    }
+
+    .section-heading h2 {
+      font-size: 1.7rem;
+    }
+
+    .stay-card {
+      display: flex;
+    }
+
+    .stay-image {
+      aspect-ratio: 16 / 9;
+    }
+
+    .highlight-more {
+      width: 100%;
+      margin-left: 0;
+      margin-top: 0.3rem;
+    }
+  }
+</style>

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Banner from '../components/Banner.astro';
+import StayChoices from '../components/StayChoices.astro';
 import Tiles from '../components/Tiles.astro';
 import { siteConfig } from '../lib/config';
 
@@ -19,6 +20,7 @@ const webSiteSchema = {
   <Banner title="密式旅行" subtitle="秘密景點，深度旅行" />
 
   <main id="main">
+    <StayChoices />
     <Tiles />
   </main>
 </BaseLayout>

--- a/astro-site/tests/homepage-stay-choices.test.ts
+++ b/astro-site/tests/homepage-stay-choices.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'cheerio';
+
+const projectDir = join(__dirname, '..');
+const distDir = join(projectDir, 'dist');
+
+function readPage(path: string) {
+  return load(readFileSync(join(distDir, path), 'utf-8'));
+}
+
+describe('首頁住宿方式入口', () => {
+  it('應在原有 tiles 前提供三種住宿方式', () => {
+    const $ = readPage('index.html');
+    const stayChoices = $('.stay-choices');
+    const tiles = $('#tiles');
+
+    expect(stayChoices).toHaveLength(1);
+    expect(tiles).toHaveLength(1);
+    expect(stayChoices.index()).toBeLessThan(tiles.index());
+
+    const links = $('.stay-card')
+      .toArray()
+      .map((element) => ({
+        href: $(element).attr('href'),
+        text: $(element).text().replace(/\s+/g, ' ').trim(),
+      }));
+
+    expect(links).toHaveLength(3);
+    expect(links[0].href).toBe('/rooms/#campsite');
+    expect(links[0].text).toContain('露營營位');
+    expect(links[0].text).toContain('3 種選擇');
+    expect(links[1].href).toBe('/rooms/#cabin');
+    expect(links[1].text).toContain('露營木屋');
+    expect(links[1].text).toContain('4 種選擇');
+    expect(links[2].href).toBe('/rooms/#suite');
+    expect(links[2].text).toContain('套房');
+    expect(links[2].text).toContain('3 種選擇');
+  });
+
+  it('三個首頁住宿入口應使用真實房型圖片', () => {
+    const $ = readPage('index.html');
+    const images = $('.stay-card img');
+
+    expect(images).toHaveLength(3);
+    images.each((_, element) => {
+      expect($(element).attr('src')).toMatch(/^\/images\//);
+      expect($(element).attr('alt')).toContain('代表住宿實景');
+      expect($(element).attr('loading')).toBe('lazy');
+    });
+  });
+
+  it('應呈現已存在於官網內容的園區特色並連到關於密式', () => {
+    const $ = readPage('index.html');
+    const highlights = $('.home-highlights').text().replace(/\s+/g, ' ');
+
+    for (const label of ['泰安山景', '上百款桌遊', '兒童遊戲室', '沙坑']) {
+      expect(highlights).toContain(label);
+    }
+
+    expect($('.home-highlights a[href="/infos/"]')).toHaveLength(1);
+  });
+
+  it('原本六張首頁功能 tiles 應完整保留', () => {
+    const $ = readPage('index.html');
+    expect($('#tiles .tile')).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## 範圍

保持既有 Banner 與六張功能 Tiles，不把首頁改成過長 Landing Page；只在兩者之間加入一個精簡住宿選擇區：

- 露營營位／露營木屋／套房三張入口卡
- 每張卡的房型數量與代表圖片直接由 Room Collection 產生，不複製營運資料
- 入口直接連到 `/rooms/#campsite`、`/rooms/#cabin`、`/rooms/#suite`
- 補一排既有官網已明確介紹的園區特色：泰安山景、上百款桌遊、兒童遊戲室、沙坑
- 保留原本六張首頁 Tiles 完整不變

## 明確不變

- 不修改 Banner 文案
- 不修改房價、規則、訂房流程或聯絡資訊
- 不新增圖片或修改字型
- 不硬編房型數量與代表圖片

## 測試

新增 build-output 回歸測試，驗證三種住宿入口、3/4/3 房型數量、真實房型圖片、特色內容，以及原六張 Tiles 都仍存在。

先以 Draft 跑完整 GitHub CI；Vercel 目前有 Hobby build-rate-limit，若 Preview 未建立會明確視為平台配額而非程式失敗。